### PR TITLE
0.2.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ Compendium 'Weapons' contains a single test weapon.
 
 ## What is working
 
+version 0.2.9 :
+
+* Bug fix forcing a fail or a pass should work as intended.
+  * Doing so will show a fail or a pass to the player.
+* Bug fix, a combat roll will now flag the skill for experience correctly.
+* You can now 'cheat' bu modifying the success level of the rolls before revealing the (blind rolls only)
+  * On blind rolls you have 2 new buttons for the keeper use only: increase/decrease success.
+  * Once your happy with the result push reveal check.
+  * Experience will not be flagged, keeper needs to manually award it with the corresponding button.
+* On blind roll, the level of success will not be revealed until you push reveal check button.
+  * Pushing force fail/pass will just indicate to the player the failure or the success with no level indication.
+
 version 0.2.8 :
 
 * Bug fix/improvement on melee flow cards.

--- a/lang/en.json
+++ b/lang/en.json
@@ -84,6 +84,8 @@
 "CoC7.check.ForcePass": "Force pass",
 "CoC7.check.ForceFail": "Force fail",
 "CoC7.check.FlagForDevelopment": "Award experience",
+"CoC7.check.IncreaseSuccessLevel": "Increase success",
+"CoC7.check.DecreaseSuccessLevel": "Decrease success",
 
 "CoC7.BonusSelectionWindow": "Bonus selection window",
 "CoC7.RegularDifficulty": "regular",

--- a/module/actors/sheets/base.js
+++ b/module/actors/sheets/base.js
@@ -161,10 +161,20 @@ export class CoC7ActorSheet extends ActorSheet {
 			const token = this.actor.token;
 			data.tokenId = token ? `${token.scene._id}.${token.id}` : null;
 
+			data.hasEmptyValueWithFormula = false;
 			for ( const characteristic of Object.values(data.data.characteristics)){
 				if( !characteristic.value) characteristic.editable = true;
 				characteristic.hard = Math.floor( characteristic.value / 2);
 				characteristic.extreme = Math.floor( characteristic.value / 5);
+
+				//If no value && no formula don't display charac.
+				if( !characteristic.value && !characteristic.formula) characteristic.display = false;
+				else characteristic.display = true;
+
+				//if any characteristic has no value but has a formula.
+				if( !characteristic.value && characteristic.formula) characteristic.hasEmptyValueWithFormula = true;
+
+				data.hasEmptyValueWithFormula = data.hasEmptyValueWithFormula || characteristic.hasEmptyValueWithFormula;
 			}
 		}
 

--- a/module/chat.js
+++ b/module/chat.js
@@ -1092,26 +1092,26 @@ export class CoC7Chat{
 			}
 			break;
 		}					
-		case 'initiator-roll': { //Roll against each target
-			let initiatorRollActor = CoC7Chat.getActorFromToken( event.currentTarget.dataset.tokenId);
-			if( initiatorRollActor == null) initiatorRollActor = game.actors.get( event.currentTarget.dataset.actorId);
+		// case 'initiator-roll': { //Roll against each target
+		// 	let initiatorRollActor = CoC7Chat.getActorFromToken( event.currentTarget.dataset.tokenId);
+		// 	if( initiatorRollActor == null) initiatorRollActor = game.actors.get( event.currentTarget.dataset.actorId);
 		
-			const initiatorCheck = new CoC7Check();
-			initiatorCheck.referenceMessageId = originMessage.dataset.messageId;
-			initiatorCheck.rollType= 'opposed';
-			initiatorCheck.side = 'initiator';
-			initiatorCheck.action = 'attack';
-			initiatorCheck.actor = initiatorRollActor;
-			initiatorCheck.difficulty = CoC7Check.difficultyLevel.regular;
-			if( event.currentTarget.dataset.outnumbered === 'true') initiatorCheck.diceModifier = +1;
+		// 	const initiatorCheck = new CoC7Check();
+		// 	initiatorCheck.referenceMessageId = originMessage.dataset.messageId;
+		// 	initiatorCheck.rollType= 'opposed';
+		// 	initiatorCheck.side = 'initiator';
+		// 	initiatorCheck.action = 'attack';
+		// 	initiatorCheck.actor = initiatorRollActor;
+		// 	initiatorCheck.difficulty = CoC7Check.difficultyLevel.regular;
+		// 	if( event.currentTarget.dataset.outnumbered === 'true') initiatorCheck.diceModifier = +1;
 
-			initiatorCheck.item = event.currentTarget.dataset.itemId;
+		// 	initiatorCheck.item = event.currentTarget.dataset.itemId;
 
-			initiatorCheck.roll();
-			initiatorCheck.toMessage();
+		// 	initiatorCheck.roll();
+		// 	initiatorCheck.toMessage();
 
-			break;
-		}
+		// 	break;
+		// }
 		case 'melee-initiator-roll':{
 			const initiator = CoC7MeleeInitiator.getFromCard( card);
 			await initiator.performSkillCheck( event.currentTarget.dataset.skill);
@@ -1169,11 +1169,24 @@ export class CoC7Chat{
 			break;
 		}
 
+		case 'increase-success-level':{
+			const check = await CoC7Check.getFromCard( card);
+			check.increaseSuccessLevel();
+			break;
+		}
+
+		case 'decrease-success-level':{
+			const check = await CoC7Check.getFromCard( card);
+			check.decreaseSuccessLevel();
+			break;
+		}
+
 		case 'reveal-check':{
 			const check = await CoC7Check.getFromCard( card);
 			check.isBlind = false;
 			check.computeCheck();
-			check.updateChatCard();
+			if( event.ctrlKey) check.updateChatCard( true);
+			else  check.updateChatCard();
 			break;
 		}
 
@@ -1209,92 +1222,6 @@ export class CoC7Chat{
 		}
 	}
 	
-	/**
-	 * TODO : unclear, confusion itemId générique et ne dépend pas de l'acteur (plusieurs acteur avec meme itemId)
-	 * @param {*} messageId 
-	 * @param {*} itemId 
-	 */
-	// static messageContainsItem( messageId, itemId){
-	// 	const chatMessage = game.messages.get( messageId);
-	// 	return !chatMessage ? false : chatMessage.data.content.includes( itemId);
-	// }
-
-
-	// static getSceneControlButtons(buttons) {
-	// 	// console.log('-->CoC7Chat.getSceneControlButtons');
-	// 	let tokenButton = buttons.find(b => b.name == 'token');
-
-	// 	if (tokenButton) {
-	// 		tokenButton.tools.push({
-	// 			name: 'request-roll',
-	// 			title: 'Request Roll',
-	// 			icon: 'fas fa-dice',
-	// 			visible: game.user.isGM,
-	// 			onClick: () => CoC7Chat.createChatCard()
-	// 		});
-	// 	}
-	// }
-	
-	// static async createChatCard(){
-	// 	const token = this.actor.token;
-	// 	const templateData = {
-	// 		actor: this.actor,
-	// 		tokenId: token ? `${token.scene._id}.${token.id}` : null,
-	// 		item: this.data
-	// 	};
-
-	// 	const template = 'systems/CoC7/templates/chat/skill-card.html';
-	// 	const html = await renderTemplate(template, templateData);
-				
-	// 	// TODO change the speaker for the token name not actor name
-	// 	const speaker = ChatMessage.getSpeaker({actor: this.actor});
-	// 	if( token) speaker.alias = token.name;
-
-	// 	await ChatMessage.create({
-	// 		user: game.user._id,
-	// 		speaker,
-	// 		content: html
-	// 	});
-	// }
-
-	// static async createAttackCard(actorId, itemId, tokenKey = null){
-
-	// 	let actor = CoC7Chat.getActorFromToken( tokenKey);
-	// 	if( actor == null) actor = game.actors.get( actorId);
-
-	// 	if( !actor) {
-	// 		ui.notifications.error(game.i18n.format('CoC7.ErrorActor'));
-	// 		return;
-	// 	}
-
-	// 	const item = actor.getOwnedItem( itemId);
-	// 	if( !item) {
-	// 		ui.notifications.error(game.i18n.format('CoC7.ErrorItem'));
-	// 		return;
-	// 	}
-
-	// 	const templateData = {
-	// 		actor: actor,
-	// 		item: item,
-	// 		tokenKey: tokenKey
-	// 	};
-
-
-	// 	const template = 'systems/CoC7/templates/chat/close-combat-card.html';
-	// 	const html = await renderTemplate(template, templateData);
-		
-	// 	const speaker = ChatMessage.getSpeaker({actor: actor});
-	// 	if( actor.isToken) speaker.alias = actor.token.name;
-
-	// 	const chatMessage = await ChatMessage.create({
-	// 		user: game.user._id,
-	// 		speaker,
-	// 		content: html
-	// 	});
-		
-	// 	CoC7Chat.updatechatMessageTargets( chatMessage);
-	// }
-
 	static async updatechatMessageTargets( oldCard){
 		const htmlCardContent = jQuery.parseHTML( oldCard.data.content);
 		const targets = htmlCardContent[0].querySelector('.targets');

--- a/module/chat/card-actor.js
+++ b/module/chat/card-actor.js
@@ -12,7 +12,12 @@ export class ChatCardActor{
     
 	get isBlind(){
 		if( !this.rollMode) return null;
-		return 'blindroll' === this.rollMode;
+		if( undefined === this._isBlind) this._isBlind = 'blindroll' === this.rollMode;
+		return this._isBlind;
+	}
+
+	set isBlind(x){
+		this._isBlind = x;
 	}
 
 	get rollMode(){

--- a/module/chat/combat/melee-initiator.js
+++ b/module/chat/combat/melee-initiator.js
@@ -40,7 +40,8 @@ export class CoC7MeleeInitiator extends ChatCardActor{
 		};
 
 		if ( ['gmroll', 'blindroll'].includes(this.rollMode) ) chatData['whisper'] = ChatMessage.getWhisperRecipients('GM');
-		if ( this.isBlind ) chatData['blind'] = true;
+		// if ( this.isBlind ) chatData['blind'] = true;
+		chatData.blind = false;
 
 		const chatMessage = await ChatMessage.create(chatData);
 		
@@ -65,6 +66,9 @@ export class CoC7MeleeInitiator extends ChatCardActor{
 
 	async performSkillCheck( skillId = null, publish = false){
 		const check = new CoC7Check();
+		// Combat roll cannot be blind or unknown
+		check.isBlind = false;
+		check.isUnkonwn = false;
 		check.referenceMessageId = this.messageId;
 		check.rollType= 'opposed';
 		check.side = 'initiator';

--- a/module/chat/combat/melee-resolution.js
+++ b/module/chat/combat/melee-resolution.js
@@ -30,7 +30,8 @@ export class CoC7MeleeResoltion{
 		
 		let rollMode = game.settings.get('core', 'rollMode');
 		if ( ['gmroll', 'blindroll'].includes(rollMode) ) chatData['whisper'] = ChatMessage.getWhisperRecipients('GM');
-		if ( rollMode === 'blindroll' ) chatData['blind'] = true;
+		// if ( rollMode === 'blindroll' ) chatData['blind'] = true;
+		chatData.blind = false;
 
 		const chatMessage = await ChatMessage.create(chatData);
 		this.messageId = chatMessage.id;

--- a/module/chat/combat/melee-target.js
+++ b/module/chat/combat/melee-target.js
@@ -124,7 +124,8 @@ export class CoC7MeleeTarget extends ChatCardActor{
 		};
 
 		if ( ['gmroll', 'blindroll'].includes(this.rollMode) ) chatData['whisper'] = ChatMessage.getWhisperRecipients('GM');
-		if ( this.isBlind ) chatData['blind'] = true;
+		// if ( this.isBlind ) chatData['blind'] = true;
+		chatData.blind = false;
 
 		const message = await ChatMessage.create(chatData);
 		
@@ -184,6 +185,9 @@ export class CoC7MeleeTarget extends ChatCardActor{
 
 	async performSkillCheck( skillId = null, publish = false){
 		const check = new CoC7Check();
+		// Combat roll cannot be blind or unknown
+		check.isBlind = false;
+		check.isUnkonwn = false;
 		check.referenceMessageId = this.messageId;
 		check.rollType= 'opposed';
 		check.side = 'target';

--- a/module/chat/damagecards.js
+++ b/module/chat/damagecards.js
@@ -69,7 +69,7 @@ export class CoC7DamageRoll extends ChatCardActor{
 		} else {
 
 			let speakerData = {};
-			if( this.actorToken) speakerData.token = this.actorToken;
+			if( this.token) speakerData.token = this.token;
 			else speakerData.actor = this.actor;
 			const speaker = ChatMessage.getSpeaker(speakerData);
 			if( this.actor.isToken) speaker.alias = this.actor.token.name;
@@ -84,7 +84,8 @@ export class CoC7DamageRoll extends ChatCardActor{
 
 			let rollMode = game.settings.get('core', 'rollMode');
 			if ( ['gmroll', 'blindroll'].includes(rollMode) ) chatData['whisper'] = ChatMessage.getWhisperRecipients('GM');
-			if ( rollMode === 'blindroll' ) chatData['blind'] = true;
+			// if ( rollMode === 'blindroll' ) chatData['blind'] = true;
+			chatData.blind = false;
 
 			await ChatMessage.create(chatData);
 		}

--- a/module/chat/rangecombat.js
+++ b/module/chat/rangecombat.js
@@ -238,7 +238,7 @@ export class CoC7RangeInitiator{
 			extremeRange: this.activeTarget.extremeRange,
 			actorKey: this.activeTarget.actorKey,
 			actorName: this.activeTarget.name,
-			difficultyLevel: this.activeTarget.shotDifficulty.level,
+			difficulty: this.activeTarget.shotDifficulty.level,
 			modifier: this.activeTarget.shotDifficulty.modifier,
 			damage: this.activeTarget.shotDifficulty.damage,
 			bulletsShot: 1,
@@ -299,7 +299,8 @@ export class CoC7RangeInitiator{
 
 		let rollMode = game.settings.get('core', 'rollMode');
 		if ( ['gmroll', 'blindroll'].includes(rollMode) ) chatData['whisper'] = ChatMessage.getWhisperRecipients('GM');
-		if ( rollMode === 'blindroll' ) chatData['blind'] = true;
+		// if ( rollMode === 'blindroll' ) chatData['blind'] = true;
+		chatData.blind = false;
 
 		const chatMessage = await ChatMessage.create(chatData);
 		
@@ -355,7 +356,7 @@ export class CoC7RangeInitiator{
 				extremeRange: this.activeTarget.extremeRange,
 				actorKey: this.activeTarget.actorKey,
 				actorName: this.activeTarget.name,
-				difficultyLevel: this.activeTarget.shotDifficulty.level,
+				difficulty: this.activeTarget.shotDifficulty.level,
 				modifier: this.activeTarget.shotDifficulty.modifier,
 				damage: this.activeTarget.shotDifficulty.damage,
 				bulletsShot: 1,
@@ -380,10 +381,13 @@ export class CoC7RangeInitiator{
 		check.actorKey = this.actorKey;
 		check.actor = this.actorKey;
 		check.item = this.itemId;
+		// Combat roll cannot be blind or unknown
+		check.isBlind = false;
+		check.isUnkonwn = false;
 		if( this.autoFire) check.skill = this.autoWeaponSkill;
 		else check.skill = this.mainWeaponSkill;
 		if( this.multiTarget){ 
-			check.difficulty = shot.difficultyLevel;
+			check.difficulty = shot.difficulty;
 			check.diceModifier = shot.modifier;
 		} else {
 			this.calcTargetsDifficulty();
@@ -440,7 +444,7 @@ export class CoC7RangeInitiator{
 		const roll = this.rolls[rollIndex];
 		const luckAmount = parseInt(roll.luckNeeded);
 		if( !this.actor.spendLuck( luckAmount)){ ui.notifications.error(`${actor.name} does not have enough luck to pass the check`); return;}
-		roll.successLevel = roll.difficultyLevel;
+		roll.successLevel = roll.difficulty;
 		roll.isSuccess = true;
 		roll.luckSpent = true;
 		this.updateChatCard();

--- a/module/check.js
+++ b/module/check.js
@@ -536,11 +536,13 @@ export class CoC7Check {
 		let cssClass = '';
 		if( this.isSuccess) cssClass = 'success';
 		if( this.isFailure) cssClass = 'failure';
-		if( this.isCritical && !this.isFailure) cssClass = 'success critical';
-		if( this.isFumble && !this.isSuccess) cssClass = 'failure fumble';
-		if( CoC7Check.successLevel.regular == this.successLevel) cssClass += ' regular-success';
-		if( CoC7Check.successLevel.hard == this.successLevel) cssClass += ' hard-success';
-		if( CoC7Check.successLevel.extreme == this.successLevel) cssClass += ' extreme-success';
+		if( !this.isBlind){
+			if( this.isCritical && !this.isFailure) cssClass = 'success critical';
+			if( this.isFumble && !this.isSuccess) cssClass = 'failure fumble';
+			if( CoC7Check.successLevel.regular == this.successLevel) cssClass += ' regular-success';
+			if( CoC7Check.successLevel.hard == this.successLevel) cssClass += ' hard-success';
+			if( CoC7Check.successLevel.extreme == this.successLevel) cssClass += ' extreme-success';
+		}
 		return cssClass;
 	}
 

--- a/module/coc7.js
+++ b/module/coc7.js
@@ -92,21 +92,25 @@ Hooks.once('init', async function() {
 	preloadHandlebarsTemplates();
 });
 
-//Hooks.on("renderChatLog", (app, html, data) => CoC7Item.chatListeners(html));
 Hooks.on('renderChatLog', (app, html, data) => CoC7Chat.chatListeners(app, html, data));
 Hooks.on('renderChatMessage', (app, html, data) => CoC7Chat.renderMessageHook(app, html, data));
 Hooks.on('updateChatMessage', (chatMessage, chatData, diff, speaker) => CoC7Chat.onUpdateChatMessage( chatMessage, chatData, diff, speaker));
-// Hooks.on('preCreateChatMessage', (app, html, data) => CoC7Chat.preCreateChatMessageHook(app, html, data));
-
 Hooks.on('ready', CoC7Chat.ready);
+
 Hooks.on('preCreateActor', (createData) => CoCActor.initToken( createData));
+
+// Used to set initiative and add the draw gun icon
 Hooks.on('renderCombatTracker', (combatTracker, html, data) => CoC7Combat.renderCombatTracker(combatTracker, html, data));
+
+// Called on closing a character sheet to lock it on getting it to display values
 Hooks.on('closeActorSheet', (characterSheet) => characterSheet.onCloseSheet());
-// Hooks.on('chatMessage', (chatLog, message, chatData) => { console.log('**************************************************************************************************chatMessage : '  + message);});
 
 
 // Add button on Token selection bar
-//Hooks.on('getSceneControlButtons', CoC7Chat.getSceneControlButtons);
+// Hooks.on('getSceneControlButtons', CoC7Chat.getSceneControlButtons);
+// Hooks.on('preCreateChatMessage', (app, html, data) => CoC7Chat.preCreateChatMessageHook(app, html, data));
+// Hooks.on('chatMessage', (chatLog, message, chatData) => { console.log('**************************************************************************************************chatMessage : '  + message);});
 
 // Hooks.on('preCreateToken', ( scene, actor, options, id) => CoCActor.preCreateToken( scene, actor, options, id))
 // Hooks.on('createToken', ( scene, actor, options, id) => CoCActor.preCreateToken( scene, actor, options, id))
+// Hooks.on("renderChatLog", (app, html, data) => CoC7Item.chatListeners(html));

--- a/module/dice.js
+++ b/module/dice.js
@@ -1,5 +1,3 @@
-// import { RollDialog } from "./apps/roll-dialog";
-
 export class CoC7Dice {
 
 	static roll( modif=0, rollMode=null)

--- a/styles/coc7.css
+++ b/styles/coc7.css
@@ -255,6 +255,7 @@
 
 .dice-roll .dice-formula.fumble{
     background-color: black;
+    color: crimson;
 }
 
 .dice-roll .dice-formula .roll-icons.success {
@@ -267,11 +268,11 @@
 }
 
 .dice-roll .dice-formula .roll-icons.failure {
-    color: red;
+    color: crimson;
 }
 
 .dice-roll .dice-formula .roll-icons.fumble {
-    color: darkred;
+    color: crimson;
     font-size: 20px;
     font-weight: bold;
 }

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
 	"name": "CoC7",
 	"title": "The Call of Cthulhu 7th edition",
 	"description": "The Call of Cthulhu 7th edition simple game system",
-	"version": "0.2.8",
+	"version": "0.2.9",
 	"author": "HavelockV",
 	"minimumCoreVersion": "0.5.2",
 	"compatibleCoreVersion": "0.6.5",
@@ -70,6 +70,6 @@
 	"secondaryTokenAttribute": "power",
 	"url": "https://github.com/HavlockV/CoC7-FoundryVTT/",
 	"manifest": "https://github.com/HavlockV/CoC7-FoundryVTT/raw/master/system.json",
-	"download": "https://github.com/HavlockV/CoC7-FoundryVTT/archive/0.2.8.zip"
+	"download": "https://github.com/HavlockV/CoC7-FoundryVTT/archive/0.2.9.zip"
   }
   

--- a/templates/actors/creature-sheet.html
+++ b/templates/actors/creature-sheet.html
@@ -17,7 +17,7 @@
 			<div class="flexrow" style="flex: 0 0 auto;display: flex;">
 			{{#each data.characteristics as |characteristic key|}}
 				{{#if ../data.flags.locked}}
-					{{#if characteristic.value}}
+					{{#if characteristic.display}}
 						<div class="flexcol" style=" margin-right: 2px;" data-characteristic="{{key}}">
 							<div class="characteristics-label rollable" style="text-align: left;">
 								<label>{{localize characteristic.short}}</label>

--- a/templates/chat/combat/melee-initiator.html
+++ b/templates/chat/combat/melee-initiator.html
@@ -10,7 +10,8 @@
     data-advantage="{{advantage}}"
     data-disadvantage="{{disadvantage}}"
     data-target-card="{{targetCard}}"
-    data-resolution-card="{{resolutionCard}}">
+    data-resolution-card="{{resolutionCard}}"
+    data-is-blind="false">
     
     <div class="roll"></div>
 
@@ -107,6 +108,7 @@
         data-fumble={{roll.fumble}}
         data-critical={{roll.critical}}
         data-characteristic={{roll.characteristic}}
+        data-is-blind="false"
         >
 		<div class="dice-result">
 			<!-- <div class="dice-formula">1D% {{#if check.dices.hasBonus}}{{check.dices.bonus}} {{check.dices.bonusType}} {{localize 'CoC7.Dice'}}{{/if}}</div> -->
@@ -153,7 +155,7 @@
                         {{/if}}
                         {{#if check.hasEnoughLuck}}
                             {{#unless check.pushing}}
-                                <button data-action="useLuck" data-luck-amount="{{check.luckNeeded}}" data-new-success-level="{{check.difficultyLevel}}">{{check.luckNeededTxt}}</button>
+                                <button data-action="useLuck" data-luck-amount="{{check.luckNeeded}}" data-new-success-level="{{check.difficulty}}">{{check.luckNeededTxt}}</button>
                             {{/unless}}
                         {{/if}}
                     {{/unless}}

--- a/templates/chat/combat/melee-resolution.html
+++ b/templates/chat/combat/melee-resolution.html
@@ -8,6 +8,7 @@
     data-winner-key="{{winner.actorKey}}"
     data-looser-key="{{looser.actorKey}}"
     data-resolved="{{resolved}}"
+    data-is-blind="false"
 >
 <header class="card-header flexcol">
     {{#if winner}}

--- a/templates/chat/combat/melee-target.html
+++ b/templates/chat/combat/melee-target.html
@@ -15,6 +15,7 @@
     data-fighting-back="{{fightingBack}}"
     data-maneuvering="{{maneuvering}}"
     data-resolution-card="{{resolutionCard}}"
+    data-is-blind="false"
     >
 
     <header class="card-header flexcol">
@@ -127,6 +128,7 @@
         data-fumble={{roll.fumble}}
         data-critical={{roll.critical}}
         data-characteristic={{roll.characteristic}}
+        data-is-blind="false"
         >
 		<div class="dice-result">
 			<!-- <div class="dice-formula">1D% {{#if check.dices.hasBonus}}{{check.dices.bonus}} {{check.dices.bonusType}} {{localize 'CoC7.Dice'}}{{/if}}</div> -->
@@ -173,7 +175,7 @@
                         {{/if}}
                         {{#if check.hasEnoughLuck}}
                             {{#unless check.pushing}}
-                            <button data-action="useLuck" data-luck-amount="{{check.luckNeeded}}" data-new-success-level="{{check.difficultyLevel}}">{{check.luckNeededTxt}}</button>
+                            <button data-action="useLuck" data-luck-amount="{{check.luckNeeded}}" data-new-success-level="{{check.difficulty}}">{{check.luckNeededTxt}}</button>
                             {{/unless}}
                         {{/if}}
                     {{/unless}}

--- a/templates/chat/combat/range-initiator.html
+++ b/templates/chat/combat/range-initiator.html
@@ -18,7 +18,8 @@
 	data-aimed="{{aimed}}"
 	data-damage-rolled="{{damageRolled}}"
 	data-total-bullets-fired="{{totalBulletsFired}}"
-	data-roll-mode={{rollMode}}>
+	data-roll-mode={{rollMode}}
+	data-is-blind="false">
 	
 	<header class="card-header flexcol">
 		<div class="flexrow">
@@ -133,6 +134,7 @@
 			data-active="{{trgt.active}}"
 			data-in-melee="{{trgt.inMelee}}"
 			data-is-GM="{{../isGM}}"
+			data-is-blind="false"
 			{{#unless trgt.active}}style='display: none;'{{/unless}}>
 			<div class="target-name">
 				<label>Target : {{trgt.name}}</label>
@@ -319,7 +321,7 @@
 				  data-shot-order="{{key}}"
 				  data-actor-key="{{shot.actorKey}}"
 				  data-actor-name="{{shot.actorName}}"
-				  data-difficulty-level="{{shot.difficultyLevel}}"
+				  data-difficulty="{{shot.difficulty}}"
 				  data-damage="{{shot.damage}}"
 				  data-modifier="{{shot.modifier}}"
 				  data-bullets-shot="{{shot.bulletsShot}}"
@@ -372,12 +374,13 @@
 				  data-pushing="{{roll.pushing}}"
 				  data-has-enough-luck="{{roll.hasEnoughLuck}}"
 				  data-luck-needed="{{roll.luckNeeded}}"
-				  data-difficulty-level="{{roll.difficultyLevel}}"
+				  data-difficulty="{{roll.difficulty}}"
 				  data-can-increase-success="{{roll.canIncreaseSuccess}}"
 				  data-has-malfunction="{{roll.hasMalfunction}}"
 				  data-malfunction-txt="{{roll.malfunctionTxt}}"
 				  data-token-id="{{roll.tokenId}}"
-				  data-index="{{key}}">
+				  data-index="{{key}}"
+				  data-is-blind="false">
 					<div class="dice-roll">
 						<div
 						class="dice-result"
@@ -444,7 +447,7 @@
 										{{/if}}
 										{{#if roll.hasEnoughLuck}}
 											{{#unless roll.pushing}}
-												<button class="pass-check" data-action="useLuck"  data-luck-amount="{{roll.luckNeeded}}" data-new-success-level="{{roll.difficultyLevel}}">{{roll.luckNeededTxt}}</button>
+												<button class="pass-check" data-action="useLuck"  data-luck-amount="{{roll.luckNeeded}}" data-new-success-level="{{roll.difficulty}}">{{roll.luckNeededTxt}}</button>
 											{{/unless}}
 										{{/if}}
 									{{/unless}}

--- a/templates/chat/roll-result.html
+++ b/templates/chat/roll-result.html
@@ -1,14 +1,19 @@
 <div class="coc7 chat-card item-card roll-card roll-result"
+	data-raw-value="{{rawValue}}" 
+	data-characteristic="{{characteristic}}" 
+	data-attribute="{{attribute}}"
+	data-skill-id="{{skill.data._id}}" 
 	data-success-required="{{successRequired}}"
 	data-flagged-for-development="{{flaggedForDevelopment}}"
-	data-foced="{{forced}}"
+	data-forced="{{forced}}"
+	data-forced-success="{{forcedSuccess}}"
+	data-forced-failure="{{forcedFailure}}"
 	data-result-type="{{resultType}}"
 	data-details="{{details}}"
 	data-can-be-pushed="{{canBePushed}}"
 	data-pushing="{{pushing}}"
 	data-has-enough-luck="{{hasEnoughLuck}}"
 	data-luck-needed="{{luckNeeded}}"
-	data-difficulty-level="{{difficultyLevel}}"
 	data-can-increase-success="{{canIncreaseSuccess}}"
 	data-has-malfunction="{{hasMalfunction}}"
 	data-malfunction-txt="{{malfunctionTxt}}"
@@ -22,21 +27,15 @@
 	data-success-level="{{successLevel}}"
 	data-difficulty="{{difficulty}}"
 	data-actor-id="{{actor._id}}" 
-	data-skill-id="{{skill.data._id}}" 
 	data-item-id="{{item.data._id}}" 
 	data-dice-mod="{{diceModifier}}"
 	data-dice-modifier="{{diceModifier}}"
 	data-ten-only-one-die="{{dices.tenOnlyOneDie}}"
-	data-value="{{value}}" 
+	data-raw-value="{{rawValue}}" 
 	data-result="{{dice.total}}"
 	data-is-success="{{isSuccess}}"
 	data-is-failure="{{isFailure}}"
 	data-is-unknown="{{isUnknown}}"
-	data-is-fumble="{{isFumble}}"
-	data-fumble="{{isFumble}}"
-	data-is-critical="{{isCritical}}"
-	data-critical="{{isCritical}}"
-	data-characteristic="{{characteristic}}" 
 	data-luck-spent="{{luckSpent}}"
 	data-gm-difficulty-regular="{{gmDifficultyRegular}}"
 	data-gm-difficulty-hard="{{gmDifficultyHard}}"
@@ -136,7 +135,7 @@
 						{{/if}}
 						{{#if hasEnoughLuck}}
 							{{#unless pushing}}
-							<button class="pass-check" data-action="useLuck" data-luck-amount="{{luckNeeded}}" data-new-success-level="{{difficultyLevel}}">{{luckNeededTxt}}</button>
+							<button class="pass-check" data-action="useLuck" data-luck-amount="{{luckNeeded}}" data-new-success-level="{{difficulty}}">{{luckNeededTxt}}</button>
 							{{/unless}}
 						{{/if}}
 					{{/unless}}
@@ -169,23 +168,31 @@
 		<div class="dice-result">
 			<div class="dice-formula">???</div>
 			{{#if forced}}
-			<h4 class="dice-total {{cssClass}}">{{#if isSuccess}}Pass !{{else}}{{#if isFailure}}Fail{{else}}??{{/if}}{{/if}}</h4>
+			<h4 class="dice-total {{cssClass}}">{{#if isSuccess}}Pass !{{else}}{{#if isFailure}}Fail !{{else}}??{{/if}}{{/if}}</h4>
 			{{else}}
 			<h4 class="dice-total">?</h4>
 			{{/if}}
 		</div>
 	</div>
 	<div class="card-buttons gm-visible-only">
+		{{#unless isUnknown}}
 		<button data-action="reveal-check">{{localize 'CoC7.check.RevealCheck'}}</button>
-		{{#if forced}}
-		{{#if isFailure}}<button data-action="force-pass">{{localize 'CoC7.check.ForcePass'}}</button>{{/if}}
-		{{#if isSuccess}}<button data-action="force-fail">{{localize 'CoC7.check.ForceFail'}}</button>{{/if}}
-		{{else}}
-		<button data-action="force-pass">{{localize 'CoC7.check.ForcePass'}}</button>
-		<button data-action="force-fail">{{localize 'CoC7.check.ForceFail'}}</button>
-		{{/if}}
+		{{/unless}}
+		{{#unless forced}}
+			{{#if isFailure}}<button data-action="force-pass">{{localize 'CoC7.check.ForcePass'}}</button>{{/if}}
+			{{#if isSuccess}}<button data-action="force-fail">{{localize 'CoC7.check.ForceFail'}}</button>{{/if}}
+			{{#unless isCritical}}
+				<button data-action="increase-success-level">{{localize 'CoC7.check.IncreaseSuccessLevel'}}</button>
+			{{/unless}}
+			{{#unless isFumble}}
+				<button data-action="decrease-success-level">{{localize 'CoC7.check.DecreaseSuccessLevel'}}</button>
+			{{/unless}}
+		{{/unless}}
+		
 		{{#unless skill.data.data.flags.developement}}
-		<button data-action="flag-for-development">{{localize 'CoC7.check.FlagForDevelopment'}}</button>
+			{{#if isSuccess}}
+				<button data-action="flag-for-development">{{localize 'CoC7.check.FlagForDevelopment'}}</button>
+			{{/if}}
 		{{/unless}}
 	</div>
 	{{/if}}

--- a/templates/chat/roll.html
+++ b/templates/chat/roll.html
@@ -24,7 +24,6 @@
 	data-pushing="{{pushing}}"
 	data-has-enough-luck="{{hasEnoughLuck}}"
 	data-luck-needed="{{luckNeeded}}"
-	data-difficulty-level="{{difficultyLevel}}"
 	data-can-increase-success="{{canIncreaseSuccess}}"
 	data-has-malfunction="{{hasMalfunction}}"
 	{{#if tokenId}}data-token-id="{{tokenId}}"{{/if}}>
@@ -88,7 +87,7 @@
 						{{/if}}
 						{{#if hasEnoughLuck}}
 							{{#unless pushing}}
-							<button data-action="useLuck" data-luck-amount="{{luckNeeded}}" data-new-success-level="{{difficultyLevel}}">{{luckNeededTxt}}</button>
+							<button data-action="useLuck" data-luck-amount="{{luckNeeded}}" data-new-success-level="{{difficulty}}">{{luckNeededTxt}}</button>
 							{{/unless}}
 						{{/if}}
 					{{/unless}}


### PR DESCRIPTION
version 0.2.9 :

* Bug fix forcing a fail or a pass should work as intended.
  * Doing so will show a fail or a pass to the player.
* Bug fix, a combat roll will now flag the skill for experience correctly.
* You can now 'cheat' bu modifying the success level of the rolls before revealing the (blind rolls only)
  * On blind rolls you have 2 new buttons for the keeper use only: increase/decrease success.
  * Once your happy with the result push reveal check.
  * Experience will not be flagged, keeper needs to manually award it with the corresponding button.
* On blind roll, the level of success will not be revealed until you push reveal check button.
  * Pushing force fail/pass will just indicate to the player the failure or the success with no level indication.