### PR TITLE
Add movement types and drop macro support to creature/NPC sheet

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1422,5 +1422,15 @@
   "CoC7.ClearExperiencePackageName": "Clear Experience Package name",
   "CoC7.SheetExperiencePackageName": "Experience",
 
-  "CoC7.AlternativeNames": "Alternative names"
+  "CoC7.AlternativeNames": "Alternative names",
+
+  "CoC7.TEMPORARY.V12.WALK": "Walk",
+  "CoC7.TEMPORARY.V12.FLY": "Fly",
+  "CoC7.TEMPORARY.V12.SWIM": "Swim",
+  "CoC7.TEMPORARY.V12.BURROW": "Burrow",
+  "CoC7.TEMPORARY.V12.CRAWL": "Crawl",
+  "CoC7.TEMPORARY.V12.CLIMB": "Climb",
+  "CoC7.TEMPORARY.V12.JUMP": "Jump",
+  "CoC7.TEMPORARY.V12.BLINK": "Teleport (Blink)",
+  "CoC7.TEMPORARY.V12.DISPLACE": "Teleport (Displace)"
 }

--- a/module/active-effect.js
+++ b/module/active-effect.js
@@ -144,7 +144,7 @@ export default class CoC7ActiveEffect extends ActiveEffect {
     // Iterate over active effects, classifying them into categories
     for (const e of effects) {
       count += 1
-      e._getSourceName() // Trigger a lookup for the source name
+      // e._getSourceName() // Trigger a lookup for the source name
       if (e.isSuppressed || e.disabled) categories.inactive.effects.push(e)
       else categories.active.effects.push(e)
     }

--- a/module/actors/sheets/base.js
+++ b/module/actors/sheets/base.js
@@ -1278,6 +1278,13 @@ export class CoC7ActorSheet extends foundry.appv1.sheets.ActorSheet {
       if (data.check === CoC7Link.CHECK_TYPE.EFFECT) {
         CoC7Link._onLinkActorClick(this.actor, data)
       }
+    } else if (['creature', 'npc'].includes(this.actor.type) && data.type === 'Macro') {
+      const macros = this.actor.system.special.macros ? foundry.utils.duplicate(this.actor.system.special.macros) : []
+      macros.push({
+        uuid: data.uuid
+      })
+      this.actor.update({ 'system.special.macros': macros })
+      return false
     }
     await super._onDrop(event)
   }

--- a/module/hooks/init.js
+++ b/module/hooks/init.js
@@ -120,4 +120,57 @@ export default function () {
       return TextEditor.createAnchor(data)
     }
   })
+
+  /* // FoundryVTT V12 */
+  if (typeof CONFIG.Token.movement === 'undefined') {
+    CONFIG.Token.movement = {
+      actions: {
+        walk: {
+          label: 'CoC7.TEMPORARY.V12.WALK',
+          icon: 'fa-solid fa-person-walking',
+          order: 0
+        },
+        fly: {
+          label: 'CoC7.TEMPORARY.V12.FLY',
+          icon: 'fa-solid fa-person-fairy',
+          order: 1
+        },
+        swim: {
+          label: 'CoC7.TEMPORARY.V12.SWIM',
+          icon: 'fa-solid fa-person-swimming',
+          order: 2
+        },
+        burrow: {
+          label: 'CoC7.TEMPORARY.V12.BURROW',
+          icon: 'fa-solid fa-person-digging',
+          order: 3
+        },
+        crawl: {
+          label: 'CoC7.TEMPORARY.V12.CRAWL',
+          icon: 'fa-solid fa-person-praying',
+          order: 4
+        },
+        climb: {
+          label: 'CoC7.TEMPORARY.V12.CLIMB',
+          icon: 'fa-solid fa-person-through-window',
+          order: 5
+        },
+        jump: {
+          label: 'CoC7.TEMPORARY.V12.JUMP',
+          icon: 'fa-solid fa-person-running-fast',
+          order: 6
+        },
+        blink: {
+          label: 'CoC7.TEMPORARY.V12.BLINK',
+          icon: 'fa-solid fa-person-from-portal',
+          order: 7
+        },
+        displace: {
+          label: 'CoC7.TEMPORARY.V12.DISPLACE',
+          icon: 'fa-solid fa-transporter-1',
+          order: 8
+        }
+      }
+    }
+  }
 }

--- a/module/scripts/handlebars-helper.js
+++ b/module/scripts/handlebars-helper.js
@@ -25,4 +25,13 @@ export const handlebarsHelper = function () {
     }
     return 0
   })
+  Handlebars.registerHelper('selectValue', function (choices, selected, valueAttr, labelAttr) {
+    if (typeof choices !== 'undefined' && typeof choices.find === 'function') {
+      const found = choices.find(o => o[valueAttr] === selected && typeof o[labelAttr] !== 'undefined')
+      if (found) {
+        return found[labelAttr]
+      }
+    }
+    return ''
+  })
 }

--- a/styles/system/main.less
+++ b/styles/system/main.less
@@ -641,6 +641,12 @@
 }
 .coc7.sheet.npc {
   min-width: 580px;
+  .auto-toggle,
+  .add-movement i,
+  .remove-movement,
+  .macro-click {
+    cursor: pointer;
+  }
   select {
     width: 100px;
     height: 16px;
@@ -739,6 +745,12 @@
 }
 .coc7.sheet.creature {
   min-width: 580px;
+  .auto-toggle,
+  .add-movement i,
+  .remove-movement,
+  .macro-click {
+    cursor: pointer;
+  }
 }
 .dice-roll {
   .dice-total.critical {

--- a/system.json
+++ b/system.json
@@ -9,7 +9,7 @@
     }
   ],
   "compatibility": {
-    "minimum": 11,
+    "minimum": 12,
     "verified": 13
   },
   "esmodules": [

--- a/template.json
+++ b/template.json
@@ -108,7 +108,8 @@
             "max": null,
             "short": "MOV",
             "label": "Movement rate",
-            "auto": true
+            "auto": true,
+            "type": "walk"
           },
           "db": {
             "value": null,
@@ -284,7 +285,9 @@
           "checkPassed": null,
           "checkFailled": null
         },
-        "attacksPerRound": 1
+        "attacksPerRound": 1,
+        "movement": [],
+        "macros": []
       },
       "infos": {
         "occupation": "",
@@ -319,7 +322,9 @@
           "checkPassed": null,
           "checkFailled": null
         },
-        "attacksPerRound": 1
+        "attacksPerRound": 1,
+        "movement": [],
+        "macros": []
       },
       "infos": {
         "type": null

--- a/templates/actors/npc-sheet.html
+++ b/templates/actors/npc-sheet.html
@@ -168,20 +168,45 @@
           {{/if}}
         </div>
 
-        <div class="attribute-list flexrow-coc7" style="flex: none;height: 20px;">
-          <div class="flexrow-coc7 flex1 attribute" data-attrib="mov">
-            <label>{{localize 'CoC7.Mov'}} :</label>
+        <div class="attribute-list flexrow-coc7" style="flex: 0 0 auto;">
+          <div style="flex: 2">
+            <div class="flexrow-coc7 flex1 attribute" data-attrib="mov">
+              <label>{{localize 'CoC7.Mov'}} :</label>
+              {{#if data.system.attribs.mov.auto}}
+                <span class="attribute-value single" type="text" style="line-height: 22px;flex: 0 0 1.54rem;"> {{data.system.attribs.mov.value}} </span>
+              {{else}}
+                <input class="attribute-value single {{#if data.system.flags.locked}}read-only{{/if}}" style="flex: 0 0 1.54rem;" type="text" name="system.attribs.mov.value" value="{{data.system.attribs.mov.value}}" data-dtype="Number" {{#if data.system.flags.locked}}readonly{{/if}}>
+              {{/if}}
 
-            {{#if data.system.attribs.mov.auto}}
-              <span class="attribute-value single" type="text" style="line-height: 22px;"> {{data.system.attribs.mov.value}} </span>
-            {{else}}
-              <input class="attribute-value single {{#if data.system.flags.locked}}read-only{{/if}}" type="text" name="system.attribs.mov.value" value="{{data.system.attribs.mov.value}}" data-dtype="Number" {{#if data.system.flags.locked}}readonly{{/if}}>
-            {{/if}}
-
+              {{#unless data.system.flags.locked}}
+                <select class="attribute-dtype" name="system.attribs.mov.type" style="height: auto;">
+                  {{selectOptions movementTypes selected=data.system.attribs.mov.type localize=true valueAttr="id" labelAttr="name"}}
+                </select>
+                <div class="auto-toggle {{#if data.system.attribs.mov.auto}}auto-on{{else}}auto-off{{/if}}" style="flex: 0 0 1.2rem"><i class="fas fa-cogs" style="padding-top: 4px;"></i></div>
+              {{else}}
+                <span class="attribute-value single" type="text" style="line-height: 22px;">{{localize (selectValue movementTypes data.system.attribs.mov.type 'id' 'name')}}</span>
+              {{/unless}}
+            </div>
+            {{#each data.system.special.movement as |movement key|}}
+              <div class="flexrow-coc7 flex1 attribute">
+                <label>{{localize 'CoC7.Mov'}} :</label>
+                <input class="attribute-value single {{#if ../data.system.flags.locked}}read-only{{/if}}" style="flex: 0 0 1.54rem;" type="text" name="system.special.movement.{{key}}.value" value="{{movement.value}}" data-dtype="Number" {{#if ../data.system.flags.locked}}readonly{{/if}}>
+                {{#unless ../data.system.flags.locked}}
+                  <select class="attribute-dtype" name="system.special.movement.{{key}}.type" style="height: auto;">
+                    {{selectOptions ../movementTypes selected=movement.type localize=true valueAttr="id" labelAttr="name"}}
+                  </select>
+                  <div class="remove-movement" style="padding-left: 4px;flex: 0 0 1.2rem" data-index="{{key}}"><i class="fas fa-minus-circle" style="padding-top: 0.3rem;"></i></div>
+                {{else}}
+                  <span class="attribute-value single" type="text" style="line-height: 22px;">{{localize (selectValue ../movementTypes movement.type 'id' 'name')}}</span>
+                {{/unless}}
+              </div>
+            {{/each}}
             {{#unless data.system.flags.locked}}
-              <div class="auto-toggle {{#if data.system.attribs.mov.auto}}auto-on{{else}}auto-off{{/if}}"><i class="fas fa-cogs" style="padding-top: 4px;"></i></div>
+              <div class="flexrow-coc7 flex1 attribute">
+                <label>{{localize 'CoC7.Mov'}} :</label>
+                <div class="add-movement"><i class="fas fa-plus-circle" style="padding-top: 0.3rem;"></i></div>
+              </div>
             {{/unless}}
-
           </div>
           <div class="flexrow-coc7 flex1 attribute" data-attrib="db" data-roll-formula="{{data.system.attribs.db.value}}">
             <label class="attribute-label rollable">{{localize 'CoC7.DB'}} :</label>
@@ -351,6 +376,22 @@
             {{editor enrichedBiographyPersonalDescription target="system.biography.personalDescription.value" engine="prosemirror" button=true owner=owner editable=editable}}
           </div>
         </section>
+
+        {{#if macros.length}}
+          <section class="sheet-section">
+            <div class="section-header flexrow-coc7" data-pannel="macros">
+              <h3 class="flex1">{{localize 'DOCUMENT.Macros'}}</h3>
+            </div>
+            <div class="macros flexcol-coc7 pannel expanded" style="padding: 0 0.2em;">
+              {{#each macros as |macro key|}}
+                <div class="flexrow">
+                  <div class="macro-click execute-macro" data-uuid="{{macro.uuid}}">{{macro.name}}</div>
+                  <div class="macro-click remove-macro" style="flex: 0 0 auto" data-index="{{key}}"><i class="fas fa-trash"></i></div>
+                </div>
+              {{/each}}
+            </div>
+          </section>
+        {{/if}}
 
         <section class="sheet-section">
           <div class="section-header flexrow-coc7" data-pannel="effects">


### PR DESCRIPTION
## Description.
Add movement type names from v13 core to v12 for backwards compatibility

## Types of Changes.
- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
