### PR TITLE
fix(actor): ensure Language (Own) is treated as unique

### DIFF
--- a/module/actors/actor.js
+++ b/module/actors/actor.js
@@ -969,50 +969,52 @@ export class CoCActor extends Actor {
           if (CoC7Item.isAnySpec(data)) {
             const isAnyButNotFlagged = (!(data.system.properties?.requiresname) ?? false) && !(data.system.properties?.picknameonly ?? false)
             let skillList = []
-            const group = game.system.api.cocid.guessGroupFromDocument(data)
-            if (group) {
-              skillList = (await game.system.api.cocid.fromCoCIDRegexBest({ cocidRegExp: new RegExp('^' + CoC7Utilities.quoteRegExp(group) + '.+$'), type: 'i' })).filter(item => {
-                return (item.system.properties?.special ?? false) && !(item.system.properties?.requiresname ?? false) && !(item.system.properties?.picknameonly ?? false)
-              })
-            }
-            if (data.system?.flags?.occupation || data.system?.flags?.archetype) {
-              const existingSkills = this.skills.filter(el => {
-                if (!el.system.specialization) return false
-                if (
-                  data.system?.flags?.occupation &&
-                  el.system.flags?.occupation
-                ) {
-                  return false
-                }
-                if (
-                  data.system?.flags?.archetype &&
-                  el.system.flags?.archetype
-                ) {
-                  return false
-                }
-                return (
-                  data.system.specialization.toLocaleLowerCase() ===
-                  el.system.specialization.toLocaleLowerCase()
-                )
-              })
-              if (existingSkills.length > 0) {
-                if (skillList.length > 0) {
-                  for (let i = existingSkills.length - 1; i >= 0; i--) {
-                    const found = skillList.findIndex(item => {
-                      return item.name === existingSkills[i].name || item.flags?.CoC7?.cocidFlag?.id === existingSkills[i].flags?.CoC7?.cocidFlag?.id
-                    })
-                    if (found > -1) {
-                      skillList.splice(found, 1)
-                    }
+            if (!data.system.properties?.onlyone) {
+              const group = game.system.api.cocid.guessGroupFromDocument(data)
+              if (group) {
+                skillList = (await game.system.api.cocid.fromCoCIDRegexBest({ cocidRegExp: new RegExp('^' + CoC7Utilities.quoteRegExp(group) + '.+$'), type: 'i' })).filter(item => {
+                  return (item.system.properties?.special ?? false) && !(item.system.properties?.requiresname ?? false) && !(item.system.properties?.picknameonly ?? false)
+                })
+              }
+              if (data.system?.flags?.occupation || data.system?.flags?.archetype) {
+                const existingSkills = this.skills.filter(el => {
+                  if (!el.system.specialization) return false
+                  if (
+                    data.system?.flags?.occupation &&
+                    el.system.flags?.occupation
+                  ) {
+                    return false
                   }
-                  skillList = skillList.concat(existingSkills)
-                } else {
-                  skillList = existingSkills
+                  if (
+                    data.system?.flags?.archetype &&
+                    el.system.flags?.archetype
+                  ) {
+                    return false
+                  }
+                  return (
+                    data.system.specialization.toLocaleLowerCase() ===
+                    el.system.specialization.toLocaleLowerCase()
+                  )
+                })
+                if (existingSkills.length > 0) {
+                  if (skillList.length > 0) {
+                    for (let i = existingSkills.length - 1; i >= 0; i--) {
+                      const found = skillList.findIndex(item => {
+                        return item.name === existingSkills[i].name || item.flags?.CoC7?.cocidFlag?.id === existingSkills[i].flags?.CoC7?.cocidFlag?.id
+                      })
+                      if (found > -1) {
+                        skillList.splice(found, 1)
+                      }
+                    }
+                    skillList = skillList.concat(existingSkills)
+                  } else {
+                    skillList = existingSkills
+                  }
                 }
               }
-            }
-            if (skillList.length > 0) {
-              skillList.sort(CoC7Utilities.sortByNameKey)
+              if (skillList.length > 0) {
+                skillList.sort(CoC7Utilities.sortByNameKey)
+              }
             }
             const skillData = await SkillSpecializationSelectDialog.create({
               skills: skillList,


### PR DESCRIPTION
## Description.

This commit corrects the handling of the 'Language (Own)' skill. Previously, due to the `requiresname: true` flag, it was incorrectly processed as a generic specialization, prompting users to select from a list of existing languages instead of inputting their native language.

The `createEmbeddedDocuments` method in `CoCActor` has been modified to check for the `onlyone: true` property on skills. If present (as is the case for 'Language (Own)'), the logic that populates the skill list for specialization selection is now bypassed.

This ensures that when 'Language (Own)' is added, the `SkillSpecializationSelectDialog` correctly prompts the user to enter a custom name for their native language, aligning with the rulebook's intent for this unique skill.

## Motivation and Context.

The previous behavior for 'Language (Own)' was confusing and did not match the expected functionality where a player defines their investigator's native tongue. This fix ensures the skill behaves as described in the Call of Cthulhu 7th Edition rules, allowing for proper character creation.

## Screenshots.

N/A (Logic change within `actor.js`)

## Types of Changes.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] Documentation change.