### PR TITLE
CCI: Open Document - See tile permission

### DIFF
--- a/docs/en/cci.md
+++ b/docs/en/cci.md
@@ -62,6 +62,7 @@ This is designed to open a Document (e.g. Journal Entry, Journal Entry Page, or 
 - **Click If** - Who can click on this region
   - Always - All users
   - Can See Document - Only users that have permission to view the document
+  - Can See Tile - Only users that have permission to view the document and can see the tile
   - Keeper - Only GM users (Keepers)
 - **Select Document** - Enter the UUID of the Document and then press the Add Document button
 - **Optional Anchor** - If the Document is a Journal Entry Page you can optionally set the anchor
@@ -107,6 +108,6 @@ This is designed to move between Scenes
 - **Can click if** - Who can click on this region
   - Always - All users
   - Keeper - Only GM users (Keepers)
-  - Can See Tile - Only users that have permission to view the Tile
+  - Can See Tile - Only users that can see the tile
 - **Select Scene** - Enter the UUID of the Scene and then press the Add Document button or Drag it here
 - **Select Tile** - Enter the UUID of the Tile and then press the Add Document button

--- a/lang/en.json
+++ b/lang/en.json
@@ -1503,6 +1503,8 @@
   "CoC7.ChaosiumCanvasInterface.OpenDocument.Document.Hint": "Which Journal Entry / Journal Entry Page / Actor",
   "CoC7.ChaosiumCanvasInterface.OpenDocument.Anchor.Title": "Optional Anchor",
   "CoC7.ChaosiumCanvasInterface.OpenDocument.Anchor.Hint": "If loading a JournalEntryPage jump to anchor",
+  "CoC7.ChaosiumCanvasInterface.OpenDocument.Tile.Title": "Select Tile",
+  "CoC7.ChaosiumCanvasInterface.OpenDocument.Tile.Hint": "Select Tile that must be visible",
   "CoC7.ChaosiumCanvasInterface.Permission.Always": "Always",
   "CoC7.ChaosiumCanvasInterface.Permission.Document": "Can See Document",
   "CoC7.ChaosiumCanvasInterface.Permission.GM": "Keeper",

--- a/module/manual/en/cci.md
+++ b/module/manual/en/cci.md
@@ -61,6 +61,7 @@ This is designed to open a Document (e.g. Journal Entry, Journal Entry Page, or 
 - **Click If** - Who can click on this region
   - Always - All users
   - Can See Document - Only users that have permission to view the document
+  - Can See Tile - Only users that have permission to view the document and can see the tile
   - Keeper - Only GM users (Keepers)
 - **Select Document** - Enter the UUID of the Document and then press the Add Document button
 - **Optional Anchor** - If the Document is a Journal Entry Page you can optionally set the anchor
@@ -106,6 +107,6 @@ This is designed to move between Scenes
 - **Can click if** - Who can click on this region
   - Always - All users
   - Keeper - Only GM users (Keepers)
-  - Can See Tile - Only users that have permission to view the Tile
+  - Can See Tile - Only users that can see the tile
 - **Select Scene** - Enter the UUID of the Scene and then press the Add Document button or Drag it here
 - **Select Tile** - Enter the UUID of the Tile and then press the Add Document button


### PR DESCRIPTION
## Description.
- Add Can See Tile permission to CCI: Open Document
- Reduce minimum allowed Document permission to limited

## Support Tested On
- [X] FoundryVTT v12.
- [X] FoundryVTT v13.

## Types of Changes.
- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] Translation (list of missing keys can be found here https://github.com/Miskatonic-Investigative-Society/CoC7-FoundryVTT/blob/develop/.github/TRANSLATIONS.md)
