### PR TITLE
Fixes for Investigator Wizard, Dholehouse Importer, and Updater

### DIFF
--- a/coc7/apps/coc-id-batch.js
+++ b/coc7/apps/coc-id-batch.js
@@ -483,6 +483,44 @@ export default class CoCIDBatch extends foundry.applications.api.HandlebarsAppli
           row['system.skill.alternativ.name'] = 'i.skill.throw'
         }
         foundItem.push(row)
+      } else if (['archetype', 'experiencePackage', 'setup', 'occupation'].includes(item.type)) {
+        const row = {}
+        const found = item.system?.itemKeys?.filter(t => t.match(/^i.skill.(firearms|fighting|ranged)-throw$/)) ?? []
+        if (found.length) {
+          const itemKeys = foundry.utils.duplicate(item.system.itemKeys)
+          let index
+          do {
+            index = itemKeys.findIndex(t => t.match(/^i.skill.(firearms|fighting|ranged)-throw$/))
+            if (index > -1) {
+              itemKeys[index] = 'i.skill.throw'
+            }
+          } while (index > -1)
+          row['system.itemKeys'] = itemKeys
+        }
+        if (['experiencePackage', 'occupation'].includes(item.type)) {
+          const groups = foundry.utils.duplicate(item.system.groups)
+          let changed = false
+          for (const index in groups) {
+            const found = groups[index].itemKeys?.filter(t => t.match(/^i.skill.(firearms|fighting|ranged)-throw$/)) ?? []
+            if (found.length) {
+              let index2
+              do {
+                index2 = groups[index].itemKeys.findIndex(t => t.match(/^i.skill.(firearms|fighting|ranged)-throw$/))
+                if (index2 > -1) {
+                  groups[index].itemKeys[index2] = 'i.skill.throw'
+                  changed = true
+                }
+              } while (index2 > -1)
+            }
+          }
+          if (changed) {
+            row['system.groups'] = groups
+          }
+        }
+        if (Object.keys(row).length) {
+          row._id = item._id
+          foundItem.push(row)
+        }
       }
     }
     for (const scene of game.scenes) {
@@ -598,6 +636,47 @@ export default class CoCIDBatch extends foundry.applications.api.HandlebarsAppli
                 row['system.skill.alternativ.name'] = 'i.skill.throw'
               }
               foundCompendiumItem[pack.collection].push(row)
+            } else if (['archetype', 'experiencePackage', 'setup', 'occupation'].includes(item.type)) {
+              if (typeof foundCompendiumItem[pack.collection] === 'undefined') {
+                foundCompendiumItem[pack.collection] = []
+              }
+              const row = {}
+              const found = item.system?.itemKeys?.filter(t => t.match(/^i.skill.(firearms|fighting|ranged)-throw$/)) ?? []
+              if (found.length) {
+                const itemKeys = foundry.utils.duplicate(item.system.itemKeys)
+                let index
+                do {
+                  index = itemKeys.findIndex(t => t.match(/^i.skill.(firearms|fighting|ranged)-throw$/))
+                  if (index > -1) {
+                    itemKeys[index] = 'i.skill.throw'
+                  }
+                } while (index > -1)
+                row['system.itemKeys'] = itemKeys
+              }
+              if (['experiencePackage', 'occupation'].includes(item.type)) {
+                const groups = foundry.utils.duplicate(item.system.groups)
+                let changed = false
+                for (const index in groups) {
+                  const found = groups[index].itemKeys?.filter(t => t.match(/^i.skill.(firearms|fighting|ranged)-throw$/)) ?? []
+                  if (found.length) {
+                    let index2
+                    do {
+                      index2 = groups[index].itemKeys.findIndex(t => t.match(/^i.skill.(firearms|fighting|ranged)-throw$/))
+                      if (index2 > -1) {
+                        groups[index].itemKeys[index2] = 'i.skill.throw'
+                        changed = true
+                      }
+                    } while (index2 > -1)
+                  }
+                }
+                if (changed) {
+                  row['system.groups'] = groups
+                }
+              }
+              if (Object.keys(row).length) {
+                row._id = item._id
+                foundCompendiumItem[pack.collection].push(row)
+              }
             }
           }
         }

--- a/coc7/apps/dholehouse-importer.js
+++ b/coc7/apps/dholehouse-importer.js
@@ -364,19 +364,19 @@ export default class CoC7DholeHouseActorImporter {
     }
     // Normalize Skills, Possessions, and Weapons
     if (typeof dholeHouseCharacterData.Investigator?.Skills?.Skill === 'undefined' || dholeHouseCharacterData.Investigator.Skills.Skill === null) {
-      foundry.setProperty(dholeHouseCharacterData, 'Investigator.Skills.Skill', [])
+      foundry.utils.setProperty(dholeHouseCharacterData, 'Investigator.Skills.Skill', [])
     } else if (!Array.isArray(dholeHouseCharacterData.Investigator.Skills.Skill)) {
-      foundry.setProperty(dholeHouseCharacterData, 'Investigator.Skills.Skill', [dholeHouseCharacterData.Investigator.Skills.Skill])
+      foundry.utils.setProperty(dholeHouseCharacterData, 'Investigator.Skills.Skill', [dholeHouseCharacterData.Investigator.Skills.Skill])
     }
     if (typeof dholeHouseCharacterData.Investigator?.Possessions?.item === 'undefined' || dholeHouseCharacterData.Investigator.Possessions.item === null) {
-      foundry.setProperty(dholeHouseCharacterData, 'Investigator.Possessions.item', [])
+      foundry.utils.setProperty(dholeHouseCharacterData, 'Investigator.Possessions.item', [])
     } else if (!Array.isArray(dholeHouseCharacterData.Investigator.Possessions.item)) {
-      foundry.setProperty(dholeHouseCharacterData, 'Investigator.Possessions.item', [dholeHouseCharacterData.Investigator.Possessions.item])
+      foundry.utils.setProperty(dholeHouseCharacterData, 'Investigator.Possessions.item', [dholeHouseCharacterData.Investigator.Possessions.item])
     }
     if (typeof dholeHouseCharacterData.Investigator?.Weapons?.weapon === 'undefined' || dholeHouseCharacterData.Investigator.Weapons.weapon === null) {
-      foundry.setProperty(dholeHouseCharacterData, 'Investigator.Weapons.weapon', [])
+      foundry.utils.setProperty(dholeHouseCharacterData, 'Investigator.Weapons.weapon', [])
     } else if (!Array.isArray(dholeHouseCharacterData.Investigator.Weapons.weapon)) {
-      foundry.setProperty(dholeHouseCharacterData, 'Investigator.Weapons.weapon', [dholeHouseCharacterData.Investigator.Weapons.weapon])
+      foundry.utils.setProperty(dholeHouseCharacterData, 'Investigator.Weapons.weapon', [dholeHouseCharacterData.Investigator.Weapons.weapon])
     }
     const progressBar = {
       current: 0,

--- a/coc7/apps/investigator-wizard.js
+++ b/coc7/apps/investigator-wizard.js
@@ -961,6 +961,7 @@ export default class CoC7InvestigatorWizard extends foundry.applications.api.Han
                     name,
                     isOccupation: row.occupationToggle,
                     isArchetype: row.archetypeToggle,
+                    isCthulhuMythos: row.isCthulhuMythos,
                     base,
                     personalPoints: row.personalPoints,
                     occupationPoints: row.occupationPoints,
@@ -1496,17 +1497,24 @@ export default class CoC7InvestigatorWizard extends foundry.applications.api.Han
         break
 
       case context.pages.PAGE_POINTS_SKILLS:
-        form.querySelectorAll('.skill-adjustment').forEach((element) => element.addEventListener('blur', async (event) => {
-          const input = event.currentTarget
-          const adjustment = input.dataset.adjustment
-          const row = input.closest('.points-row')
-          const key = row.dataset.key
-          const index = row.dataset.index
-          if (typeof this.coc7Config.skillItems[key]?.rows[index][adjustment] !== 'undefined') {
-            this.coc7Config.skillItems[key].rows[index][adjustment] = input.value
+        form.querySelectorAll('.skill-adjustment').forEach((element) => {
+          element.addEventListener('blur', async (event) => {
+            const input = event.currentTarget
+            const adjustment = input.dataset.adjustment
+            const row = input.closest('.points-row')
+            const key = row.dataset.key
+            const index = row.dataset.index
+            if (typeof this.coc7Config.skillItems[key]?.rows[index][adjustment] !== 'undefined') {
+              this.coc7Config.skillItems[key].rows[index][adjustment] = input.value
+            }
+            this.render({ force: true })
+          })
+          if (element.readOnly) {
+            element.addEventListener('dblclick', async (event) => {
+              element.readOnly = false
+            })
           }
-          this.render({ force: true })
-        }))
+        })
         break
 
       case context.pages.PAGE_INVESTIGATOR:
@@ -1607,11 +1615,13 @@ export default class CoC7InvestigatorWizard extends foundry.applications.api.Han
       return
     }
     const isMultiple = (item.system.properties.special && !item.system.properties.own && key !== this.cocidLanguageOwn && (item.system.properties.requiresname || item.system.properties.picknameonly || item.system.skillName === game.i18n.format('CoC7.AnySpecName')))
+    const isCthulhuMythos = item.flags[FOLDER_ID]?.cocidFlag?.id === 'i.skill.cthulhu-mythos' || game.i18n.localize('CoC7.CoCIDFlag.keys.i.skill.cthulhu-mythos').toLowerCase() === item.name.toLowerCase()
     const flags = {
       isOccupationDefault,
       inOccupationGroup,
       isArchetypeDefault,
       isCreditRating,
+      isCthulhuMythos,
       occupationToggle,
       archetypeToggle
     }
@@ -1882,37 +1892,39 @@ export default class CoC7InvestigatorWizard extends foundry.applications.api.Han
         specializationName: this.coc7Config.skillItems[key].item.system.specialization,
         label: this.coc7Config.skillItems[key].item.name
       })
-      if (index > -1) {
-        if (skillData.selected !== '') {
-          this.coc7Config.skillItems[key].rows[index].selected = skillList.find(i => i.id === skillData.selected)
-          this.coc7Config.skillItems[key].rows[index][toggleKey] = true
-        } else if (skillData.name !== '') {
-          this.coc7Config.skillItems[key].rows[index].selected = skillData.name
-          this.coc7Config.skillItems[key].rows[index][toggleKey] = true
+      if (skillData !== false) {
+        if (index > -1) {
+          if (skillData.selected !== '') {
+            this.coc7Config.skillItems[key].rows[index].selected = skillList.find(i => i.id === skillData.selected)
+            this.coc7Config.skillItems[key].rows[index][toggleKey] = true
+          } else if (skillData.name !== '') {
+            this.coc7Config.skillItems[key].rows[index].selected = skillData.name
+            this.coc7Config.skillItems[key].rows[index][toggleKey] = true
+          }
+        } else {
+          let selected = false
+          let newCoCId = false
+          if (skillData.selected !== '') {
+            selected = skillList.find(i => i.id === skillData.selected)
+          } else if (skillData.name !== '') {
+            selected = skillData.name
+            newCoCId = true
+          }
+          this.coc7Config.skillItems[key].rows.push({
+            isOccupationDefault: false,
+            inOccupationGroup: false,
+            isArchetypeDefault: false,
+            isCreditRating: false,
+            occupationToggle: (toggleKey === 'occupationToggle'),
+            archetypeToggle: (toggleKey === 'archetypeToggle'),
+            occupationPoints: '',
+            archetypePoints: '',
+            experiencePoints: '',
+            personalPoints: '',
+            selected,
+            newCoCId
+          })
         }
-      } else {
-        let selected = false
-        let newCoCId = false
-        if (skillData.selected !== '') {
-          selected = skillList.find(i => i.id === skillData.selected)
-        } else if (skillData.name !== '') {
-          selected = skillData.name
-          newCoCId = true
-        }
-        this.coc7Config.skillItems[key].rows.push({
-          isOccupationDefault: false,
-          inOccupationGroup: false,
-          isArchetypeDefault: false,
-          isCreditRating: false,
-          occupationToggle: (toggleKey === 'occupationToggle'),
-          archetypeToggle: (toggleKey === 'archetypeToggle'),
-          occupationPoints: '',
-          archetypePoints: '',
-          experiencePoints: '',
-          personalPoints: '',
-          selected,
-          newCoCId
-        })
       }
       this.render({ force: true })
     }

--- a/coc7/apps/updater.js
+++ b/coc7/apps/updater.js
@@ -189,7 +189,7 @@ export default class CoC7Updater {
         if (documentUpdate.parentUuid !== '') {
           options.parent = await fromUuid(documentUpdate.parentUuid)
         }
-        console.log('Migrating ' + (documentUpdate.updates.length) + ' ' + (documentUpdate.packId === '' ? 'World ' : 'Pack(' + documentUpdate.packId + ') ') + documentUpdate.type + (documentUpdate.parentUuid === '' ? '' : '(' + documentUpdate.parentUuid + ') embedded') + ' document(s)')
+        console.log('Migrating ' + (documentUpdate.updates.length) + ' ' + (documentUpdate.packId === '' ? 'World ' : 'Pack(' + documentUpdate.packId + ') ') + documentUpdate.type + (documentUpdate.parentUuid === '' ? '' : '(' + documentUpdate.parentUuid + ') embedded') + ' document(s)', documentUpdate.updates)
         if (wasLocked) {
           await game.packs.get(documentUpdate.packId).configure({ locked: false })
         }
@@ -265,7 +265,6 @@ export default class CoC7Updater {
     CoC7Updater._migrateItemArtwork({ document, documentUpdates, packId, parentUuid })
     CoC7Updater._migrateItemEmbeddedV10({ document, documentUpdates, packId, parentUuid })
     CoC7Updater._migrateItemSkillName({ document, documentUpdates, packId, parentUuid })
-    CoC7Updater._migrateItemEmbeddedDocuments({ document, documentUpdates, packId, parentUuid })
     CoC7Updater._migrateItemChases({ document, documentUpdates, packId, parentUuid })
 
     for (const offset in document.effects?.contents ?? []) {
@@ -465,13 +464,16 @@ export default class CoC7Updater {
         (document.name === 'Uniki' ? 'Unik' : document.name),
         typeof document.system?.specialization?.group === 'string' ? document.system.specialization.group : (document.system?.specialization ?? '')
       )
-      CoC7Updater.mergeEmbeddedDocuments(document, documentUpdates, 'Item', packId, parentUuid, {
-        name: parts.name,
-        'system.skillName': parts.skillName,
-        'system.specialization': parts.specialization
-      })
+      if (document.name !== parts.name || document.system.skillName !== parts.skillName || document.system.specialization !== parts.specialization) {
+        CoC7Updater.mergeEmbeddedDocuments(document, documentUpdates, 'Item', packId, parentUuid, {
+          name: parts.name,
+          'system.skillName': parts.skillName,
+          'system.specialization': parts.specialization
+        })
+      }
     } else if (['archetype', 'occupation', 'setup'].includes(document.type)) {
       const itemDocuments = foundry.utils.duplicate(document.system.itemDocuments)
+      let changed = false
       for (const offset in itemDocuments) {
         if (typeof itemDocuments[offset] === 'string') {
           itemDocuments[offset] = JSON.parse(itemDocuments[offset])
@@ -481,16 +483,22 @@ export default class CoC7Updater {
           (itemDocuments[offset].name === 'Uniki' ? 'Unik' : itemDocuments[offset].name),
           typeof itemDocuments[offset].system?.specialization?.group === 'string' ? itemDocuments[offset].system.specialization.group : (itemDocuments[offset].system?.specialization ?? '')
         )
-        foundry.utils.setProperty(itemDocuments[offset], 'name', parts.name)
-        foundry.utils.setProperty(itemDocuments[offset], 'system.skillName', parts.skillName)
-        foundry.utils.setProperty(itemDocuments[offset], 'system.specialization', parts.specialization)
-        itemDocuments[offset] = JSON.stringify(itemDocuments[offset])
+        if (itemDocuments[offset].name !== parts.name || itemDocuments[offset].system?.skillName !== parts.skillName || itemDocuments[offset].system?.specialization !== parts.specialization) {
+          foundry.utils.setProperty(itemDocuments[offset], 'name', parts.name)
+          foundry.utils.setProperty(itemDocuments[offset], 'system.skillName', parts.skillName)
+          foundry.utils.setProperty(itemDocuments[offset], 'system.specialization', parts.specialization)
+          itemDocuments[offset] = JSON.stringify(itemDocuments[offset])
+          changed = true
+        }
       }
-      CoC7Updater.mergeEmbeddedDocuments(document, documentUpdates, 'Item', packId, parentUuid, {
-        'system.itemDocuments': itemDocuments
-      })
+      if (changed) {
+        CoC7Updater.mergeEmbeddedDocuments(document, documentUpdates, 'Item', packId, parentUuid, {
+          'system.itemDocuments': itemDocuments
+        })
+      }
       if (document.type === 'occupation') {
         const groups = foundry.utils.duplicate(document.system.groups)
+        let changed = false
         for (const offset2 in groups) {
           for (const offset in groups[offset2].itemDocuments) {
             if (typeof groups[offset2].itemDocuments[offset] === 'string') {
@@ -501,55 +509,21 @@ export default class CoC7Updater {
               (groups[offset2].itemDocuments[offset].name === 'Uniki' ? 'Unik' : groups[offset2].itemDocuments[offset].name),
               typeof groups[offset2].itemDocuments[offset].system?.specialization?.group === 'string' ? groups[offset2].itemDocuments[offset].system.specialization.group : (groups[offset2].itemDocuments[offset].system?.specialization ?? '')
             )
-            foundry.utils.setProperty(groups[offset2].itemDocuments[offset], 'name', parts.name)
-            foundry.utils.setProperty(groups[offset2].itemDocuments[offset], 'system.skillName', parts.skillName)
-            foundry.utils.setProperty(groups[offset2].itemDocuments[offset], 'system.specialization', parts.specialization)
-            groups[offset2].itemDocuments[offset] = JSON.stringify(groups[offset2].itemDocuments[offset])
+            if (groups[offset2].itemDocuments[offset].name !== parts.name || groups[offset2].itemDocuments[offset].system?.skillName !== parts.skillName || groups[offset2].itemDocuments[offset].system?.specialization !== parts.specialization) {
+              foundry.utils.setProperty(groups[offset2].itemDocuments[offset], 'name', parts.name)
+              foundry.utils.setProperty(groups[offset2].itemDocuments[offset], 'system.skillName', parts.skillName)
+              foundry.utils.setProperty(groups[offset2].itemDocuments[offset], 'system.specialization', parts.specialization)
+              groups[offset2].itemDocuments[offset] = JSON.stringify(groups[offset2].itemDocuments[offset])
+              changed = true
+            }
           }
         }
-        CoC7Updater.mergeEmbeddedDocuments(document, documentUpdates, 'Item', packId, parentUuid, {
-          'system.groups': groups
-        })
+        if (changed) {
+          CoC7Updater.mergeEmbeddedDocuments(document, documentUpdates, 'Item', packId, parentUuid, {
+            'system.groups': groups
+          })
+        }
       }
-    }
-  }
-
-  /**
-   * Migrate Item Embedded Documents
-   * @param {object} options
-   * @param {object} options.document
-   * @param {object} options.documentUpdates
-   * @param {string} options.packId
-   * @param {string} options.parentUuid
-   */
-  static _migrateItemEmbeddedDocuments ({ document, documentUpdates, packId = '', parentUuid = '' } = {}) {
-    if (['archetype', 'experiencePackage', 'occupation'].includes(document.type)) {
-      CoC7Updater.mergeEmbeddedDocuments(document, documentUpdates, 'Item', packId, parentUuid, {
-        /* // FoundryVTT V13 */
-        'system.-=skills': null
-      })
-    }
-    if (['book'].includes(document.type)) {
-      CoC7Updater.mergeEmbeddedDocuments(document, documentUpdates, 'Item', packId, parentUuid, {
-        /* // FoundryVTT V13 */
-        'system.-=spells': null
-      })
-    }
-    if (['setup'].includes(document.type)) {
-      CoC7Updater.mergeEmbeddedDocuments(document, documentUpdates, 'Item', packId, parentUuid, {
-        /* // FoundryVTT V13 */
-        'system.-=items': null
-      })
-    }
-    if (['experiencePackage', 'occupation'].includes(document.type)) {
-      const groups = foundry.utils.duplicate(document.system.groups)
-      for (const index in groups) {
-        groups[index]['-=skills'] = null
-      }
-      CoC7Updater.mergeEmbeddedDocuments(document, documentUpdates, 'Item', packId, parentUuid, {
-        /* // FoundryVTT V13 */
-        'system.groups': groups
-      })
     }
   }
 
@@ -830,9 +804,11 @@ export default class CoC7Updater {
           books.push(book)
         }
       }
-      CoC7Updater.mergeEmbeddedDocuments(document, documentUpdates, 'Actor', packId, parentUuid, {
-        'system.books': books
-      })
+      if (books.length) {
+        CoC7Updater.mergeEmbeddedDocuments(document, documentUpdates, 'Actor', packId, parentUuid, {
+          'system.books': books
+        })
+      }
     }
   }
 

--- a/static/system.json
+++ b/static/system.json
@@ -2,7 +2,7 @@
   "id": "CoC7",
   "title": "Call of Cthulhu 7th Edition",
   "description": "An implementation of the Call of Cthulhu 7th Edition game system for Foundry Virtual Tabletop.",
-  "version": "8.0.16",
+  "version": "8.0.17",
   "authors": [
     {
       "name": "Miskatonic Investigative Society"

--- a/static/templates/apps/investigator-wizard/points-skills.hbs
+++ b/static/templates/apps/investigator-wizard/points-skills.hbs
@@ -15,7 +15,7 @@
       <div class="points-row flexrow" data-key="{{skill.key}}" data-index="{{skill.index}}">
         <div class="skill-name">{{skill.name}}</div>
         <div class="adjustment-value" data-tooltip="CoC7.SkillBase">{{skill.base}}</div>
-        <div class="adjustment-value" data-tooltip="CoC7.SkillPersonal"><input type="number" class="skill-adjustment" data-adjustment="personalPoints" value="{{skill.personalPoints}}"></div>
+        <div class="adjustment-value" data-tooltip="CoC7.SkillPersonal"><input type="number" class="skill-adjustment" data-adjustment="personalPoints" value="{{skill.personalPoints}}"{{#if skill.isCthulhuMythos}} readonly{{/if}}></div>
         <div class="adjustment-value" data-tooltip="CoC7.SkillOccupation">
           {{#if skill.isOccupation}}
             <input type="number" class="skill-adjustment" data-adjustment="occupationPoints" value="{{skill.occupationPoints}}">

--- a/styles/coc7-investigator-wizard.less
+++ b/styles/coc7-investigator-wizard.less
@@ -113,6 +113,10 @@
 
             input {
               text-align: center;
+
+              &:read-only {
+                cursor: default;
+              }
             }
           }
         }


### PR DESCRIPTION
## Description.
- Fix i.skill.fighting-throw to i.skill.throw migration in archetypes, experience packages, setups, and occupations
- Fix Dhole's House importer missing skills, items, and weapons detection
- Fix Investigator Wizard pressing skip on specialization selection dialog
- Prevent users adding to Cthulhu Mythos skill (double click to unlock)
- Prevent updater performing updates that don't change the document

## Support Tested On
- [X] FoundryVTT v12.
- [X] FoundryVTT v13.
- [X] FoundryVTT v14.

## Types of Changes.
- [X] AI was not used in this pull request https://foundryvtt.com/article/ai-policy/
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] Translation (list of missing keys can be found here https://github.com/Miskatonic-Investigative-Society/CoC7-FoundryVTT/blob/develop/.github/TRANSLATIONS.md)
