### PR TITLE
Fix Dholehouse Importer JSON nulls and San Data Dialog non numbers

### DIFF
--- a/coc7/apps/dholehouse-importer.js
+++ b/coc7/apps/dholehouse-importer.js
@@ -364,16 +364,25 @@ export default class CoC7DholeHouseActorImporter {
     }
     // Normalize Skills, Possessions, and Weapons
     if (typeof dholeHouseCharacterData.Investigator?.Skills?.Skill === 'undefined' || dholeHouseCharacterData.Investigator.Skills.Skill === null) {
+      if (dholeHouseCharacterData.Investigator?.Skills === null) {
+        foundry.utils.setProperty(dholeHouseCharacterData, 'Investigator.Skills', {})
+      }
       foundry.utils.setProperty(dholeHouseCharacterData, 'Investigator.Skills.Skill', [])
     } else if (!Array.isArray(dholeHouseCharacterData.Investigator.Skills.Skill)) {
       foundry.utils.setProperty(dholeHouseCharacterData, 'Investigator.Skills.Skill', [dholeHouseCharacterData.Investigator.Skills.Skill])
     }
     if (typeof dholeHouseCharacterData.Investigator?.Possessions?.item === 'undefined' || dholeHouseCharacterData.Investigator.Possessions.item === null) {
+      if (dholeHouseCharacterData.Investigator?.Possessions === null) {
+        foundry.utils.setProperty(dholeHouseCharacterData, 'Investigator.Possessions', {})
+      }
       foundry.utils.setProperty(dholeHouseCharacterData, 'Investigator.Possessions.item', [])
     } else if (!Array.isArray(dholeHouseCharacterData.Investigator.Possessions.item)) {
       foundry.utils.setProperty(dholeHouseCharacterData, 'Investigator.Possessions.item', [dholeHouseCharacterData.Investigator.Possessions.item])
     }
     if (typeof dholeHouseCharacterData.Investigator?.Weapons?.weapon === 'undefined' || dholeHouseCharacterData.Investigator.Weapons.weapon === null) {
+      if (dholeHouseCharacterData.Investigator?.Weapons === null) {
+        foundry.utils.setProperty(dholeHouseCharacterData, 'Investigator.Weapons', {})
+      }
       foundry.utils.setProperty(dholeHouseCharacterData, 'Investigator.Weapons.weapon', [])
     } else if (!Array.isArray(dholeHouseCharacterData.Investigator.Weapons.weapon)) {
       foundry.utils.setProperty(dholeHouseCharacterData, 'Investigator.Weapons.weapon', [dholeHouseCharacterData.Investigator.Weapons.weapon])

--- a/static/system.json
+++ b/static/system.json
@@ -2,7 +2,7 @@
   "id": "CoC7",
   "title": "Call of Cthulhu 7th Edition",
   "description": "An implementation of the Call of Cthulhu 7th Edition game system for Foundry Virtual Tabletop.",
-  "version": "8.0.17",
+  "version": "8.0.19",
   "authors": [
     {
       "name": "Miskatonic Investigative Society"

--- a/static/templates/apps/san-data-dialog.hbs
+++ b/static/templates/apps/san-data-dialog.hbs
@@ -1,11 +1,11 @@
 <div class="flexcol">
   <div class="form-group">
     <label>{{localize 'CoC7.MinSanloss'}}</label>
-    <input type="number" name="sanMin" value="{{sanMin}}" />
+    <input type="text" name="sanMin" value="{{sanMin}}" />
   </div>
   <div class="form-group">
     <label>{{localize 'CoC7.MaxSanloss'}}</label>
-    <input type="number" name="sanMax" value="{{sanMax}}" />
+    <input type="text" name="sanMax" value="{{sanMax}}" />
   </div>
   <div class="form-group">
     <label>{{localize 'CoC7.SanityLossTypeReason'}}</label>


### PR DESCRIPTION
## Description.
Allow die rolls in Sanity Check setup from an Actor sheet.
Fix Dholehouse Importer where JSON has null where object expected.

## Support Tested On
- [X] FoundryVTT v12.
- [X] FoundryVTT v13.
- [X] FoundryVTT v14.

## Types of Changes.
- [X] AI was not used in this pull request https://foundryvtt.com/article/ai-policy/
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] Translation (list of missing keys can be found here https://github.com/Miskatonic-Investigative-Society/CoC7-FoundryVTT/blob/develop/.github/TRANSLATIONS.md)
