### PR TITLE
Fix unable to update world settings until ready

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,6 +10,7 @@ Happy gaming !
 When not specified, all changes were made by @castanhocorreia, @HavlockV, and @snap01.
 
 - Fix NPC weapon damage from sheet with only normal range
+- Fix unable to update incorrect world settings until world is ready
 
 ## Version 8.1
 

--- a/coc7/hooks/ready.js
+++ b/coc7/hooks/ready.js
@@ -50,6 +50,18 @@ export default function () {
     }
   }
 
+  // Attempt to fix bad setting
+  if (game.settings.get(FOLDER_ID, 'InvestigatorWizardChooseValues') !== true && game.settings.get(FOLDER_ID, 'InvestigatorWizardChooseValues') !== false) {
+    game.settings.set(FOLDER_ID, 'InvestigatorWizardChooseValues', game.settings.get(FOLDER_ID, 'InvestigatorWizardChooseValues')[0] ?? false)
+  }
+  // Migrate Bout Of Madness Tables from ID to UUID
+  if (game.settings.get(FOLDER_ID, 'boutOfMadnessSummaryTable') !== 'none' && game.settings.get(FOLDER_ID, 'boutOfMadnessSummaryTable').indexOf('.') === -1) {
+    game.settings.set(FOLDER_ID, 'boutOfMadnessSummaryTable', 'RollTable.' + game.settings.get(FOLDER_ID, 'boutOfMadnessSummaryTable'))
+  }
+  if (game.settings.get(FOLDER_ID, 'boutOfMadnessRealTimeTable') !== 'none' && game.settings.get(FOLDER_ID, 'boutOfMadnessRealTimeTable').indexOf('.') === -1) {
+    game.settings.set(FOLDER_ID, 'boutOfMadnessRealTimeTable', 'RollTable.' + game.settings.get(FOLDER_ID, 'boutOfMadnessRealTimeTable'))
+  }
+
   CoC7Utilities.updateBoutTableChoices()
   deprecated.ready()
   CoC7Updater.checkForUpdate()

--- a/coc7/models/item/weapon-system.js
+++ b/coc7/models/item/weapon-system.js
@@ -479,9 +479,12 @@ export default class CoC7ModelsItemWeaponSystem extends CoC7ModelsItemGlobalSyst
    * @returns {object}
    */
   static migrateData (source) {
-    // Empty string becomes 0
-    if (source.malfunction === '') {
+    // If not a number set malfunction to null
+    if (source.malfunction === '' || (typeof source.malfunction === 'string' && isNaN(source.malfunction))) {
       foundry.utils.setProperty(source, 'malfunction', null)
+    }
+    if (source.ammo === '' || (typeof source.ammo === 'string' && isNaN(source.ammo))) {
+      foundry.utils.setProperty(source, 'ammo', 0)
     }
     // Migrate description to object
     if (typeof source.description === 'string') {

--- a/coc7/setup/register-settings.js
+++ b/coc7/setup/register-settings.js
@@ -631,16 +631,5 @@ export default function () {
     }
   })
 
-  // Attempt to fix bad setting
-  if (game.settings.get(FOLDER_ID, 'InvestigatorWizardChooseValues') !== true && game.settings.get(FOLDER_ID, 'InvestigatorWizardChooseValues') !== false) {
-    game.settings.set(FOLDER_ID, 'InvestigatorWizardChooseValues', game.settings.get(FOLDER_ID, 'InvestigatorWizardChooseValues')[0] ?? false)
-  }
-  // Migrate Bout Of Madness Tables from ID to UUID
-  if (game.settings.get(FOLDER_ID, 'boutOfMadnessSummaryTable') !== 'none' && game.settings.get(FOLDER_ID, 'boutOfMadnessSummaryTable').indexOf('.') === -1) {
-    game.settings.set(FOLDER_ID, 'boutOfMadnessSummaryTable', 'RollTable.' + game.settings.get(FOLDER_ID, 'boutOfMadnessSummaryTable'))
-  }
-  if (game.settings.get(FOLDER_ID, 'boutOfMadnessRealTimeTable') !== 'none' && game.settings.get(FOLDER_ID, 'boutOfMadnessRealTimeTable').indexOf('.') === -1) {
-    game.settings.set(FOLDER_ID, 'boutOfMadnessRealTimeTable', 'RollTable.' + game.settings.get(FOLDER_ID, 'boutOfMadnessRealTimeTable'))
-  }
   CONFIG.debug.hooks = !!game.settings.get(FOLDER_ID, 'debugmode')
 }


### PR DESCRIPTION
## Description.
Move invalid setting fixes to ready as world settings can not be changed until the world is ready.
Fix weapon dataModel malfunction and ammo migrateData

## Support Tested On
- [X] FoundryVTT v12.
- [X] FoundryVTT v13.
- [X] FoundryVTT v14.

## Types of Changes.
- [X] AI was not used in this pull request https://foundryvtt.com/article/ai-policy/
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] Translation (list of missing keys can be found here https://github.com/Miskatonic-Investigative-Society/CoC7-FoundryVTT/blob/develop/.github/TRANSLATIONS.md)
