### PR TITLE
Fixes for actor importer (spell, weapon, and weapon skills) and book initial reading

### DIFF
--- a/coc7/apps/actor-importer.js
+++ b/coc7/apps/actor-importer.js
@@ -240,7 +240,9 @@ export default class CoC7ActorImporter {
           type: 'weapon',
           system: {
             skill: {
-              id: lastPercent
+              main: {
+                id: lastPercent
+              }
             },
             properties: {},
             range: {
@@ -594,20 +596,20 @@ export default class CoC7ActorImporter {
     const updateData = {}
     let value = 0
     if (typeof characterData.actor.attribs.hp?.value !== 'undefined') {
-      this.disableAttribAuto('hp', characterData.actor.attribs.hp.value, npc.hpMax, updateData)
+      this.disableAttribAuto('hp', characterData.actor.attribs.hp.value, npc.system.attribs.hp.max, updateData)
     }
     if (typeof characterData.actor.attribs.mp?.value !== 'undefined') {
-      this.disableAttribAuto('mp', characterData.actor.attribs.mp.value, npc.mpMax, updateData)
+      this.disableAttribAuto('mp', characterData.actor.attribs.mp.value, npc.system.attribs.mp.max, updateData)
     }
     if (typeof characterData.actor.attribs.mov?.value !== 'undefined') {
-      this.disableAttribAuto('mov', characterData.actor.attribs.mov.value, npc.mov, updateData)
+      this.disableAttribAuto('mov', characterData.actor.attribs.mov.value, npc.system.attribs.mov.value, updateData)
     }
     if (typeof characterData.actor.attribs.build?.value !== 'undefined') {
-      this.disableAttribAuto('build', characterData.actor.attribs.build.value, npc.build, updateData)
+      this.disableAttribAuto('build', characterData.actor.attribs.build.value, npc.system.attribs.build.value, updateData)
     }
     if (typeof characterData.actor.attribs.db?.value !== 'undefined') {
       value = String(characterData.actor.attribs.db.value).replace(/^\+\s*/, '')
-      if (value !== String(npc.db)) {
+      if (value !== String(npc.system.attribs.db.value)) {
         updateData['system.attribs.db.auto'] = false
         updateData['system.attribs.db.value'] = value
       }
@@ -617,27 +619,6 @@ export default class CoC7ActorImporter {
         console.debug('updateData:', updateData)
       }
       await npc.update(updateData)
-    }
-    const updateItemData = []
-    let lastWeaponSkill = null
-    for (const pair of this.weaponSkills) {
-      if (pair[0] !== false) {
-        lastWeaponSkill = npc.items.filter(doc => doc.name === pair[0].name && doc.type === 'skill' && Number(doc.system.value) === Number(pair[0].system.value))
-      }
-      const weapon = npc.items.filter(doc => doc.name === pair[1].name && doc.type === 'weapon' && doc.system.range.normal.damage === pair[1].system.range.normal.damage)
-      if (lastWeaponSkill[0] && weapon[0]) {
-        updateItemData.push({
-          _id: weapon[0].id,
-          'system.skill.main.id': lastWeaponSkill[0].id,
-          'system.skill.main.name': lastWeaponSkill[0].name
-        })
-      }
-    }
-    if (updateItemData.length > 0) {
-      if (CONFIG.debug.CoC7Importer) {
-        console.debug('updateItemData:', updateItemData)
-      }
-      await npc.updateEmbeddedDocuments('Item', updateItemData)
     }
     return npc
   }
@@ -709,18 +690,33 @@ export default class CoC7ActorImporter {
    */
   async itemsData (pc) {
     const items = []
-    this.weaponSkills = []
-    // Weapon skills
+    // Weapon Skills
+    const weaponSkills = []
     if (typeof pc.attacks !== 'undefined') {
+      const foundWeapons = await CoC7Utilities.guessItems('weapon', (pc.attacks ?? []).map(i => i.name), { source: this.itemLocations, fallbackAny: true })
+      let lastSkillName = ''
       for (const attack of pc.attacks) {
-        let skill = false
-        if (attack.system?.skill?.id !== true) {
-          skill = await this.weaponSkill(attack)
-          items.push(skill)
+        if (typeof foundWeapons[attack.name] !== 'undefined') {
+          if (foundWeapons[attack.name].system?.skill?.alternativ.name) {
+            weaponSkills.push({ name: foundWeapons[attack.name].system?.skill?.alternativ.name, value: 0 })
+          }
+          if (foundWeapons[attack.name].system?.skill?.main.name) {
+            weaponSkills.push({ name: foundWeapons[attack.name].system?.skill?.main.name, value: attack.system?.skill?.main?.id })
+          }
+          items.push(foundry.utils.duplicate(foundWeapons[attack.name]))
+        } else {
+          if (attack.system?.skill?.main?.id !== true) {
+            const skill = await this.weaponSkill(attack)
+            lastSkillName = skill.name
+            attack.system.skill.main.id = null
+            attack.system.skill.main.name = lastSkillName
+            items.push(skill)
+          } else {
+            attack.system.skill.main.id = null
+            attack.system.skill.main.name = lastSkillName
+          }
+          items.push(attack)
         }
-        attack.system.skill.id = null
-        items.push(attack)
-        this.weaponSkills.push([foundry.utils.duplicate(skill), attack])
       }
     }
     // Skills
@@ -731,7 +727,7 @@ export default class CoC7ActorImporter {
         value: i.value
       }
     })
-    const foundItems = await CoC7Utilities.guessItems('skill', (pc.skills ?? []).map(i => i.name).concat(languages.map(i => i.name)), { source: this.itemLocations, fallbackAny: true })
+    const foundItems = await CoC7Utilities.guessItems('skill', weaponSkills.map(i => i.name).concat((pc.skills ?? []).map(i => i.name).concat(languages.map(i => i.name))), { source: this.itemLocations, fallbackAny: true })
     if (typeof pc.skills !== 'undefined') {
       for (const skill of pc.skills) {
         let cloned
@@ -747,9 +743,10 @@ export default class CoC7ActorImporter {
           })
         }
         foundry.utils.setProperty(cloned, 'flags.' + FOLDER_ID + '.cocidFlag.id', 'i.skill.' + CoC7Utilities.toKebabCase(cloned.name))
-        cloned.system.base = skill.value
+        foundry.utils.setProperty(cloned, 'system.base', skill.value)
+        foundry.utils.setProperty(cloned, 'system.adjustments.base', skill.value)
         if (typeof skill.push !== 'undefined') {
-          cloned.system.properties.push = skill.push
+          foundry.utils.setProperty(cloned, 'system.properties.push', skill.push)
         }
         items.push(cloned)
       }
@@ -777,9 +774,21 @@ export default class CoC7ActorImporter {
       }
       items.push(cloned)
     }
+    // Weapon Skills
+    for (const skill of weaponSkills) {
+      if (typeof foundItems[skill.name] !== 'undefined') {
+        const exists = items.find(doc => doc.name === skill.name || doc.flags?.[FOLDER_ID]?.cocidFlag?.id === skill.name)
+        if (!exists) {
+          const cloned = foundry.utils.duplicate(foundItems[skill.name])
+          foundry.utils.setProperty(cloned, 'system.base', skill.value)
+          foundry.utils.setProperty(cloned, 'system.adjustments.base', skill.value)
+          items.push(cloned)
+        }
+      }
+    }
     // Spells
     if (typeof pc.spells !== 'undefined') {
-      const foundItems = await CoC7Utilities.guessItems('skill', pc.spells, { source: this.itemLocations })
+      const foundItems = await CoC7Utilities.guessItems('spell', pc.spells, { source: this.itemLocations })
       for (const name of pc.spells) {
         let cloned
         if (typeof foundItems[name] !== 'undefined') {
@@ -860,7 +869,10 @@ export default class CoC7ActorImporter {
     if (Object.keys(skill).length > 0) {
       const skillClone = Object.values(skill)[0].clone({
         system: {
-          value: weapon.system?.skill?.id
+          base: weapon.system?.skill?.main?.id,
+          adjustments: {
+            base: weapon.system?.skill?.main?.id
+          }
         }
       })
       return skillClone
@@ -879,8 +891,8 @@ export default class CoC7ActorImporter {
           firearm: firearms,
           combat: true
         },
-        base: weapon.system?.skill?.id,
-        value: weapon.system?.skill?.id
+        base: weapon.system?.skill?.main?.id,
+        value: weapon.system?.skill?.main?.id
       }
     }
     if (CONFIG.debug.CoC7Importer) {

--- a/coc7/apps/utilities.js
+++ b/coc7/apps/utilities.js
@@ -712,12 +712,18 @@ export default class CoC7Utilities {
       let existing = []
       switch (source.substring(o, o + 1)) {
         case 'i':
+          existing = game.items.filter(doc => doc.type === type && checkList.includes(doc.flags?.[FOLDER_ID]?.cocidFlag?.id.toLocaleLowerCase()))
+          for (const item of existing) {
+            if (typeof foundItems[item.flags[FOLDER_ID].cocidFlag.id] === 'undefined') {
+              foundItems[item.flags[FOLDER_ID].cocidFlag.id] = item
+            }
+          }
           existing = game.items.filter(doc => doc.type === type && checkList.includes(doc.name.toLocaleLowerCase()))
           for (const item of existing) {
             const name = item.name.toLocaleLowerCase()
             if (typeof foundItems[name] === 'undefined') {
               foundItems[name] = item
-            } else if (typeof foundItems[name].flags?.CoC7?.cocidFlag?.id === 'undefined' && typeof item.flags?.CoC7?.cocidFlag?.id === 'string') {
+            } else if (typeof foundItems[name].flags?.[FOLDER_ID]?.cocidFlag?.id === 'undefined' && typeof item.flags?.[FOLDER_ID]?.cocidFlag?.id === 'string') {
               foundItems[name] = item
             }
           }
@@ -728,12 +734,18 @@ export default class CoC7Utilities {
           for (const pack of game.packs) {
             if (pack.metadata.type === 'Item' && ['wworld', 'ssystem', 'mmodule'].includes(source[o] + pack.metadata.packageType)) { // cspell:disable-line
               const documents = await pack.getDocuments()
+              existing = documents.filter(doc => doc.type === type && checkList.includes(doc.flags?.[FOLDER_ID]?.cocidFlag?.id.toLocaleLowerCase()))
+              for (const item of existing) {
+                if (typeof foundItems[item.flags[FOLDER_ID].cocidFlag.id] === 'undefined') {
+                  foundItems[item.flags[FOLDER_ID].cocidFlag.id] = item
+                }
+              }
               existing = documents.filter(doc => doc.type === type && checkList.includes(doc.name.toLocaleLowerCase()))
               for (const item of existing) {
                 const name = item.name.toLocaleLowerCase()
                 if (typeof foundItems[name] === 'undefined') {
                   foundItems[name] = item
-                } else if (typeof foundItems[name].flags?.CoC7?.cocidFlag?.id === 'undefined' && typeof item.flags?.CoC7?.cocidFlag?.id === 'string') {
+                } else if (typeof foundItems[name].flags?.[FOLDER_ID]?.cocidFlag?.id === 'undefined' && typeof item.flags?.[FOLDER_ID]?.cocidFlag?.id === 'string') {
                   foundItems[name] = item
                 }
               }
@@ -743,14 +755,14 @@ export default class CoC7Utilities {
       }
     }
     const cocids = Object.keys(foundItems).reduce((c, d) => {
-      if (typeof foundItems[d].flags?.CoC7?.cocidFlag?.id === 'string') {
-        c[foundItems[d].flags.CoC7.cocidFlag.id] = d
+      if (typeof foundItems[d].flags?.[FOLDER_ID]?.cocidFlag?.id === 'string') {
+        c[foundItems[d].flags[FOLDER_ID].cocidFlag.id] = d
       }
       return c
     }, {})
     const found = await game.CoC7.cocid.fromCoCIDRegexBest({ cocidRegExp: game.CoC7.cocid.makeGroupRegEx(Object.keys(cocids)), type: 'i', showLoading: true })
     for (const item of found) {
-      const cocid = item.flags.CoC7.cocidFlag.id
+      const cocid = item.flags[FOLDER_ID].cocidFlag.id
       const key = cocids[cocid]
       foundItems[key] = item
     }

--- a/coc7/models/item/book-sheet.js
+++ b/coc7/models/item/book-sheet.js
@@ -68,7 +68,7 @@ export default class CoC7ModelsItemBookSheet extends CoC7ModelsItemGlobalSheet {
         label: 'CoC7.Details'
       }
     }
-    if ((context.document.system.type.mythos || context.document.system.type.occult) && (game.user.isGM || context.document.initialReading)) {
+    if ((context.document.system.type.mythos || context.document.system.type.occult) && (game.user.isGM || (knownBook?.initialReading ?? false))) {
       tabs.spells = {
         icon: '',
         label: 'CoC7.Spells'

--- a/coc7/models/item/book-system.js
+++ b/coc7/models/item/book-system.js
@@ -438,7 +438,7 @@ export default class CoC7ModelsItemBookSystem extends CoC7ModelsItemGlobalSystem
    */
   async updateRoll (check) {
     if (check.isSuccess) {
-      if (this.testUserPermission(game.user, CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER)) {
+      if (this.parent.testUserPermission(game.user, CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER)) {
         switch (check.callbackContext) {
           case 'attemptInitialReading':
             await this.grantInitialReading()

--- a/coc7/models/item/document-class.js
+++ b/coc7/models/item/document-class.js
@@ -540,6 +540,9 @@ export default class CoC7ModelsItemDocumentClass extends Item {
         }
       )
     }
+    if (object.type === 'weapon' && object.system.properties.rngd === false) {
+      output.properties.push(game.i18n.localize('CoC7.Weapon.Property.Melee'))
+    }
     for (const key in object.system.properties) {
       if (object.system.properties[key]) {
         output.properties.push(game.i18n.localize(CONFIG.Item.dataModels[object.type].defineSchema().properties.getField(key).label))

--- a/static/lang/sv.json
+++ b/static/lang/sv.json
@@ -227,7 +227,7 @@
   "CoC7.RollDifficultyImpossible": "Omöjlig",
   "CoC7.RollDifficultyImpossibleTitle": "Omöjlig svårighetsgrad",
   "CoC7.RollResult.LuckSpendText": "{luckAmount} turpoäng använda, {successLevel} framgång",
-  "CoC7.RollDice": "Slål !",
+  "CoC7.RollDice": "Slå!",
   "CoC7.CreateLink": "Skapa länk",
   "CoC7.SuccessLevelHint": "{value} nivå(er) av framgång",
   "CoC7.FailureLevelHint": "Misslyckades med {value} nivå(er)",

--- a/static/templates/actors/npc-v2/tab/combat.hbs
+++ b/static/templates/actors/npc-v2/tab/combat.hbs
@@ -82,7 +82,7 @@
         <div class="combat-toggle toggle-row flexrow">
           <div class="toggle-attributes flexrow" data-set="properties">
             {{#each ../_properties as |row|}}
-              <button class="toggle-switch{{#if (lookup weapon.system.properties row.id)}} switched-on{{/if}}" data-apply-to="item" data-property="{{row.id}}" {{#if row.tooltip}}data-tooltip="{{row.tooltip}}" {{/if}} type="button">{{localize row.name}}</button>
+              <button class="toggle-switch{{#if (eq row.id 'melee')}}{{#if (not weapon.system.properties.rngd)}} switched-on{{/if}}{{else if (lookup weapon.system.properties row.id)}} switched-on{{/if}}" data-apply-to="item" data-property="{{row.id}}" {{#if row.tooltip}}data-tooltip="{{row.tooltip}}" {{/if}} type="button">{{localize row.name}}</button>
             {{/each}}
           </div>
         </div>


### PR DESCRIPTION
## Description.
Fix actor importer not looking for spells
Fix books initial reading error and spell tab for players (Resolves #2015)
Fix NPC combat section melee tag toggle (Resolves #2019)
Fix melee tag not showing up in weapon.chatData
Recreate #2014 in moved json file (Resolves #2014)
Update actor importer weapon / weapon skill detection and creation

## Support Tested On
- [X] FoundryVTT v12.
- [X] FoundryVTT v13.
- [X] FoundryVTT v14.

## Types of Changes.
- [X] AI was not used in this pull request https://foundryvtt.com/article/ai-policy/
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] Translation (list of missing keys can be found here https://github.com/Miskatonic-Investigative-Society/CoC7-FoundryVTT/blob/develop/.github/TRANSLATIONS.md)
