### PR TITLE
Allow completing a book full study if book is now exhausted

### DIFF
--- a/coc7/models/actor/global-system.js
+++ b/coc7/models/actor/global-system.js
@@ -357,22 +357,23 @@ export default class CoC7ModelsActorGlobalSystem extends foundry.abstract.TypeDa
       books[offset].fullStudies++
       // Grant Full Study
       if (document.system.type.mythos && document.system.mythosRating > 0) {
-        if ((await document.system.checkExhaustion()) === false) {
-          const cthulhuMythosSkill = this.parent.cthulhuMythosSkill
-          if (cthulhuMythosSkill) {
-            const mythosIncrease = Math.min(document.system.mythosRating, cthulhuMythosSkill.system.value + document.system.gains.cthulhuMythos.final) - cthulhuMythosSkill.system.value
-            if (mythosIncrease > 0) {
-              const developments = [{
-                name: cthulhuMythosSkill.name,
-                gain: mythosIncrease
-              },
-              {
-                name: document.system.language,
-                gain: 'development'
-              }]
-              await document.system.grantSkillDevelopment(developments)
-              await document.system.rollSanityLoss()
-            }
+        const cthulhuMythosSkill = this.parent.cthulhuMythosSkill
+        if (cthulhuMythosSkill) {
+          let mythosIncrease = document.system.gains.cthulhuMythos.initial
+          if (cthulhuMythosSkill.system.value < document.system.mythosRating) {
+            mythosIncrease = document.system.gains.cthulhuMythos.final
+          }
+          if (mythosIncrease > 0) {
+            const developments = [{
+              name: cthulhuMythosSkill.name,
+              gain: mythosIncrease
+            },
+            {
+              name: document.system.language,
+              gain: 'development'
+            }]
+            await document.system.grantSkillDevelopment(developments)
+            await document.system.rollSanityLoss()
           }
         }
       }

--- a/coc7/models/item/book-sheet.js
+++ b/coc7/models/item/book-sheet.js
@@ -111,7 +111,6 @@ export default class CoC7ModelsItemBookSheet extends CoC7ModelsItemGlobalSheet {
           context.units = knownBook.units
           context.studyCompleted = knownBook.progress === knownBook.necessary
           context.mythos = context.document.system.type.mythos
-          context.exhausted = (await context.document.system.checkExhaustion()) !== false
         }
         break
       case 'description':
@@ -279,12 +278,18 @@ export default class CoC7ModelsItemBookSheet extends CoC7ModelsItemGlobalSheet {
           }
           break
         case 'increase-progress':
-          await this.document.system.alterProgress(1)
-          this.render()
+          {
+            const alter = await this.alterProgressBy(event, true)
+            await this.document.system.alterProgress(alter)
+            this.render()
+          }
           break
         case 'decrease-progress':
-          await this.document.system.alterProgress(-1)
-          this.render()
+          {
+            const alter = await this.alterProgressBy(event, false)
+            await this.document.system.alterProgress(alter)
+            this.render()
+          }
           break
         case 'redo-full-study':
           await this.document.system.redoFullStudy()
@@ -369,5 +374,46 @@ export default class CoC7ModelsItemBookSheet extends CoC7ModelsItemGlobalSheet {
       others.splice(parseInt(index, 10), 1)
       await this.document.update({ 'system.gains.others': others })
     }
+  }
+
+  /**
+   * Get value to alter progress by
+   * @param {ClickEvent} event
+   * @param {boolean} increase
+   */
+  async alterProgressBy (event, increase) {
+    let alter = 1
+    const knownBook = this.document.actor?.system.getBook(this.document)
+    /* // FoundryVTT V12 */
+    if (game.release.generation > 12 && knownBook && event.shiftKey) {
+      const max = Number(increase ? knownBook.necessary - knownBook.progress : knownBook.progress)
+      if (max > 1) {
+        alter = await new Promise((resolve, reject) => {
+          foundry.applications.api.DialogV2.prompt({
+            window: { title: 'CoC7.BookAlterProgress' },
+            form: { closeOnSubmit: false },
+            content: '<div class="flexrow"><label>' + game.i18n.format('CoC7.BookProgressValue', { max }) + ':</label><input type="number" value="" style="flex: 0 0 3rem" min="1" max="' + max + '" step="1" autofocus required name="alter">',
+            ok: {
+              label: 'CoC7.Validate',
+              icon: 'fa-solid fa-check',
+              callback: (event, button, dialog) => {
+                if (!button.form.elements.alter.validity.valid) {
+                  button.form.reportValidity()
+                  return
+                }
+                return button.form.elements.alter.valueAsNumber
+              }
+            },
+            submit: (result, dialog) => {
+              if (!isNaN(result)) {
+                dialog.close()
+                resolve(result)
+              }
+            }
+          })
+        })
+      }
+    }
+    return (increase ? alter : -alter)
   }
 }

--- a/coc7/models/item/book-system.js
+++ b/coc7/models/item/book-system.js
@@ -182,34 +182,8 @@ export default class CoC7ModelsItemBookSystem extends CoC7ModelsItemGlobalSystem
       if (currentProgress < necessary) {
         const progress = Math.min(necessary, currentProgress + parseInt(modify, 10))
         await this.parent.actor?.system.updateBook(this.parent, { progress })
-        if (await this.checkExhaustion() && progress === necessary) {
-          /* // FoundryVTT V12 */
-          ui.notifications.warn(game.i18n.format('CoC7.BookHasNothingMoreToTeach', { actor: this.parent.actor.name, book: this.parent.name }))
-        }
       }
     }
-  }
-
-  /**
-   * Check if book can still reward Cthulhu Mythos improvements
-   * @returns {boolean}
-   */
-  async checkExhaustion () {
-    const knownBook = this.parent.actor?.system.getBook(this.parent)
-    if (knownBook?.initialReading === true) {
-      const mythosRating = this.mythosRating
-      if (mythosRating > 0) {
-        const cthulhuMythosSkill = this.parent.actor.cthulhuMythosSkill
-        if (cthulhuMythosSkill && cthulhuMythosSkill.system.value >= mythosRating) {
-          if (knownBook.progress > 0 && knownBook.progress < knownBook.necessary) {
-            // You've started, so you'll finish
-            return false
-          }
-          return true
-        }
-      }
-    }
-    return false
   }
 
   /**

--- a/coc7/models/item/book-system.js
+++ b/coc7/models/item/book-system.js
@@ -201,6 +201,10 @@ export default class CoC7ModelsItemBookSystem extends CoC7ModelsItemGlobalSystem
       if (mythosRating > 0) {
         const cthulhuMythosSkill = this.parent.actor.cthulhuMythosSkill
         if (cthulhuMythosSkill && cthulhuMythosSkill.system.value >= mythosRating) {
+          if (knownBook.progress > 0 && knownBook.progress < knownBook.necessary) {
+            // You've started, so you'll finish
+            return false
+          }
           return true
         }
       }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -768,7 +768,8 @@
   "CoC7.SpellSuccessfullyLearned": "Spell '{spell}' was learned successfully!",
   "CoC7.SpellAlreadyLearned": "Spell named ('{spell}') was already learned.",
 
-  "CoC7.BookHasNothingMoreToTeach": "{book} has nothing more to teach. Cthulhu Mythos skill of {actor} is greater than this Mythos Rating.",
+  "CoC7.BookAlterProgress": "Study progress quantity",
+  "CoC7.BookProgressValue": "Number to alter progress by (1 - {max})",
   "CoC7.BookType": "Book Type",
   "CoC7.Content": "Content",
   "CoC7.CthulhuMythosFinal": "Mythos Final",

--- a/static/templates/items/book-header.hbs
+++ b/static/templates/items/book-header.hbs
@@ -25,14 +25,14 @@
           <label>{{localize 'CoC7.InitialReading'}}</label>
           <label><i class="fa-solid fa-check"></i></label>
         </div>
-        <div class="flexrow">
-          <label>{{localize 'CoC7.FullStudies'}}:</label>
-          <label>{{fullStudies}}</label>
-          {{#if (and studyCompleted (not exhausted))}}
-            <a class="item-control" data-action="redo-full-study" data-tooltip="CoC7.RedoFullStudy"><i class="fa-solid fa-redo"></i></a>
-          {{/if}}
-        </div>
-        {{#if (gt document.system.mythosRating 0)}}
+        {{#if mythos}}
+          <div class="flexrow">
+            <label>{{localize 'CoC7.FullStudies'}}:</label>
+            <label>{{fullStudies}}</label>
+            {{#if studyCompleted}}
+              <a class="item-control" data-action="redo-full-study" data-tooltip="CoC7.RedoFullStudy"><i class="fa-solid fa-redo"></i></a>
+            {{/if}}
+          </div>
           <div class="flexrow">
             <button class="item-control" data-action="attemptReference">{{localize 'CoC7.ReferenceTome'}}</button>
           </div>
@@ -45,12 +45,12 @@
   </div>
   <div class="spell-progress flexrow">
     {{#if (and mythos (or isKeeper initialReading) isEmbedded)}}
-      {{#if (and isKeeper (not exhausted))}}
-        <a class="item-control" data-action="decrease-progress"><i class="fa-regular fa-minus-circle"></i></a>
+      {{#if isKeeper}}
+        <a class="{{#if (lt progress necessary)}}item-control{{else}}item-control-disabled{{/if}}" data-action="decrease-progress"><i class="fa-regular fa-minus-circle"></i></a>
       {{/if}}
-      <progress name="system.study.progress" value="{{progress}}" max="{{necessary}}" {{#unless exhausted}} data-label="{{localize 'CoC7.Progress'}}: {{progress}} / {{necessary}} {{localize units}}"{{/unless}}></progress>
-      {{#if (and isKeeper (not exhausted))}}
-        <a class="item-control" data-action="increase-progress"><i class="fa-regular fa-plus-circle"></i></a>
+      <progress name="system.study.progress" value="{{progress}}" max="{{necessary}}" data-label="{{localize 'CoC7.Progress'}}: {{progress}} / {{necessary}} {{localize units}}"></progress>
+      {{#if isKeeper}}
+        <a class="{{#if (lt progress necessary)}}item-control{{else}}item-control-disabled{{/if}}" data-action="increase-progress"><i class="fa-regular fa-plus-circle"></i></a>
       {{/if}}
     {{else}}
       &nbsp;

--- a/styles/coc7-items.less
+++ b/styles/coc7-items.less
@@ -32,10 +32,17 @@
       padding: @4px @16px;
       gap: @8px;
 
-      a.item-control {
+      a.item-control,
+      a.item-control-disabled {
         margin-top: @2px;
         flex: 0 0 auto;
       }
+
+      a.item-control-disabled {
+        opacity: 0.2;
+        pointer-events: none;
+      }
+
 
       progress {
         background: none;


### PR DESCRIPTION
- Remove tome exhaustion checks, once a Full Study is completed check Actor's Cthulhu Mythos value if less than Tome's Mythos Rating add CMF otherwise add CMI (Keeper's Rulebook p174)
- Allow shift click + / - progress to alter progress by more than one (Not FoundryVTT v12 compatible)

## Support Tested On
- [X] FoundryVTT v12.
- [X] FoundryVTT v13.
- [X] FoundryVTT v14.

## Types of Changes.
- [X] AI was not used in this pull request https://foundryvtt.com/article/ai-policy/
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] Translation (list of missing keys can be found here https://github.com/Miskatonic-Investigative-Society/CoC7-FoundryVTT/blob/develop/.github/TRANSLATIONS.md)
