### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/coc7/hooks/render-game-pause.js
+++ b/coc7/hooks/render-game-pause.js
@@ -26,5 +26,5 @@ export default function (application, element, context, options) {
   } else {
     element.querySelector('img').setAttribute('src', imageReplacement)
   }
-  element.querySelector('figcaption').innerHTML = textReplacement
+  element.querySelector('figcaption').textContent = textReplacement
 }

--- a/coc7/hooks/render-pause.js
+++ b/coc7/hooks/render-pause.js
@@ -26,5 +26,5 @@ export default function (application, html, data) {
   } else {
     html.find('img').attr('src', imageReplacement)
   }
-  html.find('figcaption').html(textReplacement)
+  html.find('figcaption').text(textReplacement)
 }


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `Medium` | **File**: `coc7/hooks/render-game-pause.js:L22`

User-configurable setting `artPauseText` is written directly into the DOM with `innerHTML`/`html(...)` when rendering the pause overlay. A malicious value can inject arbitrary HTML/JS-like payloads (depending on client HTML handling), which then renders for all connected users.

## Solution

Avoid `innerHTML` for untrusted or configurable text. Use `textContent` (or jQuery `.text()`) for plain text, or sanitize explicitly with a strict HTML sanitizer before insertion.

## Changes

- `coc7/hooks/render-game-pause.js` (modified)
- `coc7/hooks/render-pause.js` (modified)