### PR TITLE
Replace StandardJS with ESLint

### DIFF
--- a/coc7/apps/actor-importer-dialog.js
+++ b/coc7/apps/actor-importer-dialog.js
@@ -1,4 +1,4 @@
-/* global CONFIG FileReader foundry game Hooks ui */
+/* global CONFIG foundry game Hooks ui */
 // cSpell:words iwms wmis
 import { FOLDER_ID } from '../constants.js'
 import CoC7ActorImporter from './actor-importer.js'
@@ -233,8 +233,7 @@ export default class CoC7ActorImporterDialog extends foundry.applications.api.Ha
         this.coc7Config.convert6E = formData.object['coc-convert-6E']
         this.coc7Config.source = formData.object.source
         if (this.coc7Config.importType === 'dholehouse' && typeof this.coc7Config.characterJSON?.Investigator?.PersonalDetails !== 'undefined') {
-          const app = document.getElementById('actor-importer-dialog')
-          app.style.display = 'none'
+          form.style.display = 'none'
           const character = await CoC7DholeHouseActorImporter.createNPCFromDholeHouse(this.coc7Config.characterJSON, { source: this.coc7Config.source })
           if (character !== false) {
             if (CONFIG.debug.CoC7Importer) {
@@ -248,7 +247,7 @@ export default class CoC7ActorImporterDialog extends foundry.applications.api.Ha
             await character.sheet.render({ force: true })
             this.close()
           } else {
-            app.style.display = ''
+            form.style.display = ''
           }
         } else if (this.coc7Config.characterData !== '') {
           this.close()

--- a/coc7/apps/content-link-dialog.js
+++ b/coc7/apps/content-link-dialog.js
@@ -1,4 +1,4 @@
-/* global ActiveEffectConfig canvas CONFIG CONST DragDrop FormDataExtended foundry game SubmitEvent ui */
+/* global ActiveEffectConfig canvas CONFIG CONST DragDrop FormDataExtended foundry game ui */
 import { FOLDER_ID } from '../constants.js'
 import CoC7DicePool from './dice-pool.js'
 import CoC7Link from './link.js'

--- a/coc7/apps/delayed-tooltip.js
+++ b/coc7/apps/delayed-tooltip.js
@@ -1,4 +1,4 @@
-/* global DOMParser foundry game */
+/* global foundry game */
 
 export default class CoC7DelayedTooltip {
   /**

--- a/coc7/apps/dholehouse-importer.js
+++ b/coc7/apps/dholehouse-importer.js
@@ -1,4 +1,4 @@
-/* global Actor CONFIG fetch foundry game ui */
+/* global Actor CONFIG foundry game ui */
 // cSpell:words injurues malf subskill skillname
 import { FOLDER_ID } from '../constants.js'
 import CoC7ModelsItemSkillSystem from '../models/item/skill-system.js'

--- a/coc7/apps/tour.js
+++ b/coc7/apps/tour.js
@@ -1,4 +1,4 @@
-/* global foundry game MutationObserver Tour ui */
+/* global foundry game Tour ui */
 /* // FoundryVTT V12 */
 export default class CoC7Tour extends (foundry.nue?.Tour ?? Tour) {
   /**

--- a/coc7/apps/utilities.js
+++ b/coc7/apps/utilities.js
@@ -1,4 +1,4 @@
-/* global Actor canvas ChatMessage CONFIG CONST Folder foundry fromUuid fromUuidSync game getComputedStyle Hooks Macro Ray Roll Token TokenDocument ui */
+/* global Actor canvas ChatMessage CONFIG CONST Folder foundry fromUuid fromUuidSync game Hooks Macro Ray Roll Token TokenDocument ui */
 import { FOLDER_ID, STATUS_EFFECTS, TARGET_ALLOWED, TRADE_ALLOWED } from '../constants.js'
 import CoC7ActorPickerDialog from './actor-picker-dialog.js'
 import CoC7DicePool from './dice-pool.js'

--- a/coc7/deprecated.js
+++ b/coc7/deprecated.js
@@ -319,7 +319,7 @@ class DeprecatedWarningCoC7DamageCard {
    * @inheritdoc
    * @deprecated No replacement
    */
-  static get defaultOptions () {
+  static get defaultOptions () { // eslint-disable-line getter-return
     deprecated.noLongerAvailable({ was: 'game.CoC7.cards.CoC7DamageCard.defaultOptions()' })
   }
 

--- a/coc7/hooks/render-game-pause.js
+++ b/coc7/hooks/render-game-pause.js
@@ -1,4 +1,4 @@
-/* global game */
+/* global foundry game */
 import { FOLDER_ID } from '../constants.js'
 
 /**
@@ -26,5 +26,5 @@ export default function (application, element, context, options) {
   } else {
     element.querySelector('img').setAttribute('src', imageReplacement)
   }
-  element.querySelector('figcaption').innerHTML = textReplacement
+  element.querySelector('figcaption').innerHTML = foundry.utils.cleanHTML(textReplacement)
 }

--- a/coc7/models/actor/document-class.js
+++ b/coc7/models/actor/document-class.js
@@ -58,7 +58,7 @@ export default class CoC7ModelsActorDocumentClass extends Actor {
    * Not required
    * @deprecated No replacement
    */
-  get characteristics () {
+  get characteristics () { // eslint-disable-line getter-return
     deprecated.noLongerAvailable({ was: 'Actor.initialize' })
   }
 
@@ -3443,8 +3443,8 @@ export default class CoC7ModelsActorDocumentClass extends Actor {
   /**
    * Development Phase
    * @param {bool} fastForward
-   * @param {bool} isDeprecated @deprecated
-   * @returns {object} @deprecated
+   * @param {bool} isDeprecated \@deprecated
+   * @returns {object} \@deprecated
    */
   async developmentPhase (fastForward = false, isDeprecated = false) {
     this.onlyRunOncePerSession = true

--- a/coc7/models/chase/participant.js
+++ b/coc7/models/chase/participant.js
@@ -42,7 +42,7 @@ export default class CoC7ChaseParticipant {
 
   /**
    * Get the actor
-   * @throws Error if not loaded
+   * @throws {Error} if not loaded
    * @returns {Document|null}
    */
   get actor () {
@@ -54,7 +54,7 @@ export default class CoC7ChaseParticipant {
 
   /**
    * Is this an Actor that can be in a chase
-   * @throws Error if not loaded
+   * @throws {Error} if not loaded
    * @returns {boolean}
    */
   get isActor () {
@@ -66,7 +66,7 @@ export default class CoC7ChaseParticipant {
 
   /**
    * Get actor icon or default icon
-   * @throws Error if not loaded
+   * @throws {Error} if not loaded
    * @returns {string}
    */
   get icon () {
@@ -391,7 +391,7 @@ export default class CoC7ChaseParticipant {
   /**
    * Get the actor weapons
    * @param {string} otherDamage
-   * @throws Error if not loaded
+   * @throws {Error} if not loaded
    * @returns {object}
    */
   actorWeapons (otherDamage) {

--- a/coc7/models/item/book-system.js
+++ b/coc7/models/item/book-system.js
@@ -277,7 +277,7 @@ export default class CoC7ModelsItemBookSystem extends CoC7ModelsItemGlobalSystem
 
   /**
    * Receives an Array of skills and handles all the logic to develop them
-   * @param {Array} developments @see grantInitialReading
+   * @param {Array} developments \@see grantInitialReading
    * @returns {Promise<Document|void>} create ChatMessage
    */
   async grantSkillDevelopment (developments) {

--- a/coc7/models/item/chase-sheet.js
+++ b/coc7/models/item/chase-sheet.js
@@ -226,7 +226,7 @@ export default class CoC7ModelsItemChaseSheet extends CoC7ModelsItemGlobalSheet 
                 })
               }
             }
-            new (foundry.applications.ux?.ContextMenu?.implementation ?? ContextMenu)(element, '.assist-dropdown', contextOptions, { // eslint-disable-line no-new, new-cap
+            new (foundry.applications.ux?.ContextMenu?.implementation ?? ContextMenu)(element, '.assist-dropdown', contextOptions, {
               jQuery: false,
               fixed: true,
               eventName: 'click'

--- a/coc7/models/item/chase-system.js
+++ b/coc7/models/item/chase-system.js
@@ -626,7 +626,7 @@ export default class CoC7ModelsItemChaseSystem extends CoC7ModelsItemGlobalSyste
       locations[offset].participants.splice(offset2, 1)
       locations[newLocation].participants.push(participantId)
       participants[participantIndex].currentMovementActions -= totalMove
-      if (typeof locations[newLocation].coordinates.x && typeof locations[newLocation].coordinates.y === 'number') {
+      if (typeof locations[newLocation].coordinates.x === 'number' && typeof locations[newLocation].coordinates.y === 'number') {
         await this.moveTokenToLocation(participantId, locations[newLocation].coordinates)
       }
       await this.parent.update({ 'system.participants': participants, 'system.locations.list': locations })
@@ -650,7 +650,7 @@ export default class CoC7ModelsItemChaseSystem extends CoC7ModelsItemGlobalSyste
       if (offset > -1) {
         locations[oldLocation].participants.splice(offset, 1)
         locations[newLocation].participants.push(participantId)
-        if (typeof locations[newLocation].coordinates.x && typeof locations[newLocation].coordinates.y === 'number') {
+        if (typeof locations[newLocation].coordinates.x === 'number' && typeof locations[newLocation].coordinates.y === 'number') {
           await this.moveTokenToLocation(participantId, locations[newLocation].coordinates)
         }
         await this.parent.update({ 'system.locations.list': locations }, { render })

--- a/coc7/setup/register-settings.js
+++ b/coc7/setup/register-settings.js
@@ -45,15 +45,15 @@ export default function () {
     /* // FoundryVTT V12 */
     choices: foundry.utils.isNewerVersion(game.version, 13)
       ? () => Object.entries(ERAS).reduce((c, e) => {
-          c.push({
-            value: e[0],
-            label: game.i18n.localize(e[1].name)
-          })
-          return c
-        }, []).sort(CoC7Utilities.sortByLabelKey).reduce((c, e) => {
-          c[e.value] = e.label
-          return c
-        }, {})
+        c.push({
+          value: e[0],
+          label: game.i18n.localize(e[1].name)
+        })
+        return c
+      }, []).sort(CoC7Utilities.sortByLabelKey).reduce((c, e) => {
+        c[e.value] = e.label
+        return c
+      }, {})
       : Object.entries(ERAS).reduce((c, e) => {
         c[e[0]] = e[1].name
         return c

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,18 +1,38 @@
+import globals from 'globals'
+import js from '@eslint/js'
 import jsdoc from 'eslint-plugin-jsdoc'
+import pluginImport from 'eslint-plugin-import'
+import stylistic from '@stylistic/eslint-plugin'
 
 const config = [
   jsdoc.configs['flat/recommended'],
+  js.configs.recommended,
   {
     files: ['**/*.js'],
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...globals.node
+      }
+    },
     plugins: {
-      jsdoc
+      import: pluginImport,
+      jsdoc,
+      '@stylistic': stylistic
     },
     rules: {
-      'jsdoc/require-description': 'warn',
-      'jsdoc/no-undefined-types': 0,
-      'jsdoc/require-param-description': 0,
-      'jsdoc/require-returns-description': 0,
-      'jsdoc/require-jsdoc': [
+      'no-empty': ['error', { 'allowEmptyCatch': true }], // Allow empty catch blocks
+      'no-unused-vars': ['warn', { 'args': 'none', 'caughtErrors': 'none' }], // Allow unused function arguments
+      'no-undef': 'error', // Disallow the use of undeclared variables unless mentioned in /*global */ comments
+
+      // --- eslint-plugin-jsdoc ---
+      'jsdoc/reject-function-type': 0, // Reports use of Function type within JSDoc tag types.
+      'jsdoc/reject-any-type': 0, // Reports use of any (or *) type within JSDoc tag types.
+      'jsdoc/require-description': 'warn', // Requires that all functions (and potentially other contexts) have a description.
+      'jsdoc/no-undefined-types': 0, // Besides some expected built-in types, prohibits any types not specified as globals or within @typedef.
+      'jsdoc/require-param-description': 0, // Requires that each @param tag has a description value.
+      'jsdoc/require-returns-description': 0, // Requires that the @returns tag has a description value (not including void/undefined type returns).
+      'jsdoc/require-jsdoc': [ // Checks for presence of JSDoc comments, on functions and potentially other contexts (optionally limited to exports).
         'warn',
         {
           require: {
@@ -20,7 +40,25 @@ const config = [
             MethodDefinition: true
           }
         }
-      ]
+      ],
+
+      // --- @stylistic/eslint-plugin ---
+      '@stylistic/indent': ['error', 2], // Force 2-space indentation
+      '@stylistic/quotes': ['error', 'single', { 'avoidEscape': true }], // Use single quotes
+      '@stylistic/semi': ['error', 'never'], // No semicolons at end of lines
+      '@stylistic/comma-dangle': ['error', 'never'], // No trailing commas in objects/arrays
+      '@stylistic/object-curly-spacing': ['error', 'always'], // Spaces inside braces: { key: value }
+      '@stylistic/arrow-spacing': ['error', { 'before': true, 'after': true }], // Spaces in arrow functions: () => {}
+      '@stylistic/comma-spacing': ['error', { 'before': false, 'after': true }], // Spaces in x, x
+      '@stylistic/space-before-function-paren': ['error', 'always'],
+
+      // --- eslint-plugin-import Rules ---
+      'import/no-unresolved': 'error', // Ensure all imports resolve to valid files
+      'import/named': 'error', // Verify named imports exist in the target module
+      'import/default': 'error', // Ensure default imports are valid
+      'import/namespace': 'error', // Verify namespace imports are correct
+      'import/export': 'error', // Report any invalid exports
+      'import/no-absolute-path': 'error' // Forbid absolute paths in imports
     }
   }
 ]

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "build": "webpack --mode production",
     "compendiums-build": "node scripts/compendiums-build.js",
     "eslint": "eslint coc7/ scripts/",
-    "format": "standard --fix",
     "game-icons-build": "node scripts/game-icons-build.js",
     "init": "node scripts/init.js",
     "manuals-build": "node scripts/manuals-build.js",
@@ -28,20 +27,20 @@
   "homepage": "https://github.com/Miskatonic-Investigative-Society/CoC7-FoundryVTT#readme",
   "type": "module",
   "devDependencies": {
-    "@vusion/webfonts-generator": "^0.8.0",
+    "@stylistic/eslint-plugin": "^5.10.0",
     "classic-level": "^3.0.0",
     "copy-webpack-plugin": "^14.0.0",
     "css-loader": "^7.0.0",
     "css-minimizer-webpack-plugin": "^8.0.0",
     "decompress": "^4.0.0",
-    "eslint-plugin-jsdoc": "^51.0.0",
+    "eslint-plugin-import": "^2.32.0",
+    "eslint-plugin-jsdoc": "^62.0.0",
     "less-loader": "^12.0.0",
     "mini-css-extract-plugin": "^2.0.0",
     "node-fetch": "^3.0.0",
     "remarkable": "^2.0.0",
-    "standard": "^17.0.0",
     "thread-loader": "^4.0.0",
-    "webpack-cli": "^6.0.0",
+    "webpack-cli": "^7.0.0",
     "webpackbar": "^7.0.0"
   }
 }

--- a/scripts/game-icons-build.js
+++ b/scripts/game-icons-build.js
@@ -3,7 +3,7 @@ import * as path from 'path'
 import decompress from 'decompress'
 import fetch from 'node-fetch'
 import TemplateHelpers from './src/template-helpers.js'
-import webfontsGenerator from '@vusion/webfonts-generator'
+import webfontsGenerator from '@vusion/webfonts-generator' // eslint-disable-line import/no-unresolved
 
 // npm run game-icons-build -- --help
 

--- a/scripts/webpack-config.js
+++ b/scripts/webpack-config.js
@@ -232,19 +232,19 @@ export default class WebpackConfig {
     /** Set optimization options for production only */
     const optimization = (this.#config.buildMode === 'production')
       ? {
-          minimize: true,
-          minimizer: [
-            new TerserPlugin({
-              terserOptions: {
-                mangle: false
-              }
-            }),
-            new CssMinimizerPlugin()
-          ],
-          splitChunks: {
-            chunks: 'all'
-          }
+        minimize: true,
+        minimizer: [
+          new TerserPlugin({
+            terserOptions: {
+              mangle: false
+            }
+          }),
+          new CssMinimizerPlugin()
+        ],
+        splitChunks: {
+          chunks: 'all'
         }
+      }
       : undefined
 
     /**


### PR DESCRIPTION
## Description.
StandardJS dependencies are out of date replace with ESLint (#1863)
Remove @vusion/webfonts-generator with no replacement for now
For FoundryVTT v13+ implement foundry.utils.cleanHTML to not break pause text styling (closes #2047)

## Support Tested On
- [X] FoundryVTT v12.
- [X] FoundryVTT v13.
- [X] FoundryVTT v14.

## Types of Changes.
- [X] AI was not used in this pull request https://foundryvtt.com/article/ai-policy/
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] Translation (list of missing keys can be found here https://github.com/Miskatonic-Investigative-Society/CoC7-FoundryVTT/blob/develop/.github/TRANSLATIONS.md)
