### PR TITLE
Chase Speed Check, Region Behaviors filter, roll normalize bonus dice

### DIFF
--- a/coc7/apps/clickable-events.js
+++ b/coc7/apps/clickable-events.js
@@ -99,8 +99,9 @@ export default class CoC7ClickableEvents extends foundry.data.regionBehaviors.Re
         for (const region of canvas.scene.regions.contents) {
           /* // FoundryVTT V12 */
           const polygonTree = region.object?.document.polygonTree ?? region.object.polygonTree
-          if (region.behaviors.filter(b => !b.disabled).find(b => b.system instanceof CoC7ClickableEvents || b.system instanceof ChaosiumCanvasInterface) && polygonTree.testPoint(destination)) {
-            region.behaviors.filter(b => !b.disabled).map(async (b) => { if (await b.system._handleMouseOverEvent() === true && typeof b.system._handleLeftClickEvent === 'function') { await b.system._handleLeftClickEvent() } })
+          const behaviors = region.behaviors.filter(b => !b.disabled && (b.system instanceof CoC7ClickableEvents || b.system instanceof ChaosiumCanvasInterface) && polygonTree.testPoint(destination))
+          if (behaviors) {
+            behaviors.map(async (b) => { if (await b.system._handleMouseOverEvent() === true && typeof b.system._handleLeftClickEvent === 'function') { await b.system._handleLeftClickEvent() } })
           }
         }
       }
@@ -114,8 +115,9 @@ export default class CoC7ClickableEvents extends foundry.data.regionBehaviors.Re
         for (const region of canvas.scene.regions.contents) {
           /* // FoundryVTT V12 */
           const polygonTree = region.object?.document.polygonTree ?? region.object.polygonTree
-          if (region.behaviors.filter(b => !b.disabled).find(b => b.system instanceof CoC7ClickableEvents || b.system instanceof ChaosiumCanvasInterface) && polygonTree.testPoint(destination)) {
-            region.behaviors.filter(b => !b.disabled).map(async (b) => { if (await b.system._handleMouseOverEvent() === true && typeof b.system._handleRightClickEvent === 'function') { await b.system._handleRightClickEvent() } })
+          const behaviors = region.behaviors.filter(b => !b.disabled && (b.system instanceof CoC7ClickableEvents || b.system instanceof ChaosiumCanvasInterface) && polygonTree.testPoint(destination))
+          if (behaviors) {
+            behaviors.map(async (b) => { if (await b.system._handleMouseOverEvent() === true && typeof b.system._handleRightClickEvent === 'function') { await b.system._handleRightClickEvent() } })
           }
         }
       }
@@ -132,8 +134,9 @@ export default class CoC7ClickableEvents extends foundry.data.regionBehaviors.Re
         for (const region of canvas.scene.regions.contents) {
           /* // FoundryVTT V12 */
           const polygonTree = region.object?.document.polygonTree ?? region.object.polygonTree
-          if (region.behaviors.filter(b => !b.disabled).find(b => b.system instanceof CoC7ClickableEvents || b.system instanceof ChaosiumCanvasInterface) && polygonTree.testPoint(destination)) {
-            setPointer = await region.behaviors.filter(b => !b.disabled).reduce(async (c, b) => {
+          const behaviors = region.behaviors.filter(b => !b.disabled && (b.system instanceof CoC7ClickableEvents || b.system instanceof ChaosiumCanvasInterface) && polygonTree.testPoint(destination))
+          if (behaviors) {
+            setPointer = await behaviors.reduce(async (c, b) => {
               const r = await b.system._handleMouseOverEvent()
               if (r !== false && r !== true) {
                 console.error(b.uuid + ' did not return a boolean')

--- a/coc7/apps/roll-normalize.js
+++ b/coc7/apps/roll-normalize.js
@@ -144,7 +144,7 @@ export default class CoC7RollNormalize {
             config.displayName = item.name
           }
           if (config.poolModifier === 0) {
-            config.poolModifier = item.system.bonusDice
+            config.poolModifier = item.system.bonusDice ?? 0
           }
           okay = true
         } else if (item.type === 'weapon') {
@@ -154,7 +154,7 @@ export default class CoC7RollNormalize {
             config.displayName = item.name
           }
           if (config.poolModifier === 0) {
-            config.poolModifier = item.system.bonusDice
+            config.poolModifier = item.system.bonusDice ?? 0
           }
           okay = true
         } else {
@@ -174,7 +174,7 @@ export default class CoC7RollNormalize {
           }
         }
         if (config.poolModifier === 0) {
-          config.poolModifier = options.actor.system.attribs[config.key].bonusDice
+          config.poolModifier = options.actor.system.attribs[config.key].bonusDice ?? 0
         }
         okay = true
       } else if (typeof options.characteristic !== 'undefined' && typeof options.actor.system.characteristics[options.characteristic] !== 'undefined') {
@@ -187,7 +187,7 @@ export default class CoC7RollNormalize {
           }
         }
         if (config.poolModifier === 0) {
-          config.poolModifier = options.actor.system.characteristics[config.key].bonusDice
+          config.poolModifier = options.actor.system.characteristics[config.key].bonusDice ?? 0
         }
         okay = true
       }

--- a/coc7/models/chase/participant.js
+++ b/coc7/models/chase/participant.js
@@ -150,7 +150,7 @@ export default class CoC7ChaseParticipant {
   get movAdjustment () {
     if (CoC7DicePool.isValidPool(this.#participant.speedCheck?.checkData?.flags?.[FOLDER_ID].load?.dicePool)) {
       const dicePool = CoC7DicePool.fromObject(this.#participant.speedCheck.checkData.flags[FOLDER_ID].load.dicePool)
-      if (dicePool.isCritical) {
+      if (dicePool.isCritical || dicePool.isExtremeSuccess) {
         return 1
       } else if (!dicePool.isSuccess) {
         return -1


### PR DESCRIPTION
## Description.
- Fix Chase Item Speed Check for Extreme Successes not just Critical success (Resolves #2069)
- Filter Region Behaviours instead of find and map
- Prevent roll bonus dice defaulting to NaN

## Support Tested On
- [X] FoundryVTT v12.
- [X] FoundryVTT v13.
- [X] FoundryVTT v14.

## Types of Changes.
- [X] AI was not used in this pull request https://foundryvtt.com/article/ai-policy/
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] Translation (list of missing keys can be found here https://github.com/Miskatonic-Investigative-Society/CoC7-FoundryVTT/blob/develop/.github/TRANSLATIONS.md)
